### PR TITLE
fix Zig 0.15.2 compatibility for Windows HTTPS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,7 @@ pub fn build(b: *std.Build) void {
         if (target.result.os.tag == .windows) {
             exe.linkSystemLibrary("ws2_32");
             exe.linkSystemLibrary("mswsock");
+            exe.linkLibC();
         }
 
         const install_exe = b.addInstallArtifact(exe, .{});
@@ -75,6 +76,7 @@ pub fn build(b: *std.Build) void {
         if (target.result.os.tag == .windows) {
             exe.linkSystemLibrary("ws2_32");
             exe.linkSystemLibrary("mswsock");
+            exe.linkLibC();
         }
 
         const install_exe = b.addInstallArtifact(exe, .{});
@@ -102,6 +104,7 @@ pub fn build(b: *std.Build) void {
     if (target.result.os.tag == .windows) {
         tests.linkSystemLibrary("ws2_32");
         tests.linkSystemLibrary("mswsock");
+        tests.linkLibC();
     }
 
     const run_tests = b.addRunArtifact(tests);
@@ -124,6 +127,7 @@ pub fn build(b: *std.Build) void {
     if (target.result.os.tag == .windows) {
         bench_exe.linkSystemLibrary("ws2_32");
         bench_exe.linkSystemLibrary("mswsock");
+        bench_exe.linkLibC();
     }
 
     const install_bench = b.addInstallArtifact(bench_exe, .{});

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -197,7 +197,7 @@ pub const Client = struct {
                 if (policy.retry_on_connection_error and can_retry_method and attempt < policy.max_retries) {
                     attempt += 1;
                     const delay_ms = policy.calculateDelay(attempt);
-                    if (delay_ms > 0) std.time.sleep(delay_ms * std.time.ns_per_ms);
+                    if (delay_ms > 0) std.Thread.sleep(delay_ms * std.time.ns_per_ms);
                     continue;
                 }
                 return err;
@@ -207,7 +207,7 @@ pub const Client = struct {
                 res.deinit();
                 attempt += 1;
                 const delay_ms = policy.calculateDelay(attempt);
-                if (delay_ms > 0) std.time.sleep(delay_ms * std.time.ns_per_ms);
+                if (delay_ms > 0) std.Thread.sleep(delay_ms * std.time.ns_per_ms);
                 continue;
             }
 
@@ -290,6 +290,7 @@ pub const Client = struct {
 
         const w = try session.getWriter();
         try w.writeAll(request_data);
+        try session.flushWriter();
 
         const r = try session.getReader();
         return self.readResponseFromIo(r);
@@ -316,15 +317,18 @@ pub const Client = struct {
         var parser = Parser.initResponse(self.allocator);
         defer parser.deinit();
 
-        var buf: [16 * 1024]u8 = undefined;
         while (!parser.isComplete()) {
-            var iov = [_][]u8{buf[0..]};
-            const n = r.readVec(&iov) catch |err| switch (err) {
-                error.EndOfStream => 0,
-                else => return err,
+            // Ensure at least 1 byte is available in the reader's buffer.
+            // The TLS reader decrypts records into its internal buffer.
+            _ = r.peek(1) catch |err| switch (err) {
+                error.EndOfStream => break,
+                error.ReadFailed => return err,
             };
-            if (n == 0) break;
-            _ = try parser.feed(buf[0..n]);
+            // Feed all buffered decrypted data to the parser.
+            const buffered = r.buffer[r.seek..r.end];
+            if (buffered.len == 0) break;
+            _ = try parser.feed(buffered);
+            r.seek += buffered.len;
         }
 
         parser.finishEof();

--- a/src/httpx.zig
+++ b/src/httpx.zig
@@ -136,6 +136,8 @@ pub const Response = response.Response;
 pub const ResponseBuilder = response.ResponseBuilder;
 
 pub const Socket = socket.Socket;
+pub const SocketIoReader = socket.SocketIoReader;
+pub const SocketIoWriter = socket.SocketIoWriter;
 pub const TcpListener = socket.TcpListener;
 pub const UdpSocket = socket.UdpSocket;
 

--- a/src/net/address.zig
+++ b/src/net/address.zig
@@ -18,7 +18,7 @@ pub fn resolve(hostname: []const u8, port: u16) !net.Address {
     }
 
     if (parseIp6(hostname)) |ip6| {
-        return net.Address.initIp6(ip6, 0, port);
+        return net.Address.initIp6(ip6, port, 0, 0);
     }
 
     const list = try net.getAddressList(std.heap.page_allocator, hostname, port);

--- a/src/net/socket.zig
+++ b/src/net/socket.zig
@@ -74,50 +74,74 @@ pub const SocketIoReader = struct {
         return @fieldParentPtr("reader", r);
     }
 
-    fn stream(r: *Io.Reader, w: *Io.Writer, limit: Io.Limit) Io.Reader.StreamError!usize {
-        var total: usize = 0;
-
-        while (total < limit.toInt(usize)) {
-            const max_to_read = @min(r.buffer.len, limit.toInt(usize) - total);
-            var iov = [_][]u8{r.buffer[0..max_to_read]};
-            const n = readVec(r, &iov) catch |err| switch (err) {
-                error.EndOfStream => break,
-                else => return err,
-            };
-            if (n == 0) break;
-
-            try w.writeAll(r.buffer[0..n]);
-            total += n;
-        }
-
-        return total;
-    }
-
-    fn discard(r: *Io.Reader, limit: Io.Limit) Io.Reader.StreamRemainingError!usize {
-        var total: usize = 0;
-
-        while (total < limit.toInt(usize)) {
-            const max_to_read = @min(r.buffer.len, limit.toInt(usize) - total);
-            var iov = [_][]u8{r.buffer[0..max_to_read]};
-            const n = readVec(r, &iov) catch |err| switch (err) {
-                error.EndOfStream => break,
-                else => return err,
-            };
-            if (n == 0) break;
-            total += n;
-        }
-
-        return total;
-    }
-
-    fn readVec(r: *Io.Reader, bufs: [][]u8) Io.Reader.Error!usize {
-        const p = parent(r);
-        if (bufs.len == 0) return 0;
-        const buf = bufs[0];
-        const n = p.socket.recv(buf) catch return error.ReadFailed;
-        if (n == 0) return error.EndOfStream;
+    fn stream(io_r: *Io.Reader, io_w: *Io.Writer, limit: Io.Limit) Io.Reader.StreamError!usize {
+        const dest = limit.slice(try io_w.writableSliceGreedy(1));
+        var bufs: [1][]u8 = .{dest};
+        const n = try readVec(io_r, &bufs);
+        io_w.advance(n);
         return n;
     }
+
+    fn readVec(io_r: *Io.Reader, data: [][]u8) Io.Reader.Error!usize {
+        const p = parent(io_r);
+        if (is_windows) {
+            const windows = std.os.windows;
+            var iovecs: [max_buffers_len]windows.ws2_32.WSABUF = undefined;
+            const bufs_n, const data_size = try io_r.writableVectorWsa(&iovecs, data);
+            const bufs = iovecs[0..bufs_n];
+            if (bufs.len == 0 or bufs[0].len == 0) return 0;
+
+            var flags: u32 = 0;
+            var overlapped: windows.OVERLAPPED = std.mem.zeroes(windows.OVERLAPPED);
+            var n: u32 = undefined;
+
+            if (windows.ws2_32.WSARecv(
+                p.socket.handle,
+                bufs.ptr,
+                @intCast(bufs.len),
+                &n,
+                &flags,
+                &overlapped,
+                null,
+            ) == windows.ws2_32.SOCKET_ERROR) {
+                switch (windows.ws2_32.WSAGetLastError()) {
+                    .WSA_IO_PENDING => {
+                        var result_flags: u32 = undefined;
+                        if (windows.ws2_32.WSAGetOverlappedResult(
+                            p.socket.handle,
+                            &overlapped,
+                            &n,
+                            windows.TRUE,
+                            &result_flags,
+                        ) == windows.FALSE) return error.ReadFailed;
+                    },
+                    else => return error.ReadFailed,
+                }
+            }
+
+            if (n == 0) return error.EndOfStream;
+            if (n > data_size) {
+                io_r.end += n - data_size;
+                return data_size;
+            }
+            return n;
+        } else {
+            var bufs: [max_buffers_len][]u8 = undefined;
+            const bufs_n, const data_size = try io_r.writableVector(&bufs, data);
+            const real_bufs = bufs[0..bufs_n];
+            if (real_bufs.len == 0 or real_bufs[0].len == 0) return 0;
+
+            const n = p.socket.recv(real_bufs[0]) catch return error.ReadFailed;
+            if (n == 0) return error.EndOfStream;
+            if (n > data_size) {
+                io_r.end += n - data_size;
+                return data_size;
+            }
+            return n;
+        }
+    }
+
+    const max_buffers_len = 8;
 
     fn rebase(_: *Io.Reader, _: usize) Io.Reader.RebaseError!void {
         // Sockets are not seekable; nothing to do.
@@ -125,7 +149,6 @@ pub const SocketIoReader = struct {
 
     const vtable: Io.Reader.VTable = .{
         .stream = stream,
-        .discard = discard,
         .readVec = readVec,
         .rebase = rebase,
     };
@@ -153,37 +176,43 @@ pub const SocketIoWriter = struct {
         return @fieldParentPtr("writer", w);
     }
 
-    fn drain(w: *Io.Writer, bufs: []const []const u8, start_index: usize) Io.Writer.Error!usize {
+    fn drain(w: *Io.Writer, data: []const []const u8, splat: usize) Io.Writer.Error!usize {
         const p = parent(w);
-        var i: usize = start_index;
-        while (i < bufs.len and bufs[i].len == 0) : (i += 1) {}
-        if (i >= bufs.len) return 0;
+        const buffered = w.buffered();
+        var total_sent: usize = 0;
 
-        const n = p.socket.send(bufs[i]) catch return error.WriteFailed;
-        return n;
-    }
-
-    fn sendFile(w: *Io.Writer, file_reader: *std.fs.File.Reader, limit: Io.Limit) Io.Writer.FileAllError!usize {
-        const p = parent(w);
-
-        var total: usize = 0;
-        while (total < limit.toInt(usize)) {
-            const remaining = limit.toInt(usize) - total;
-            const chunk_len = @min(w.buffer.len, remaining);
-            if (chunk_len == 0) break;
-
-            const n_read = file_reader.read(w.buffer[0..chunk_len]) catch return error.ReadFailed;
-            if (n_read == 0) break;
-
-            p.socket.sendAll(w.buffer[0..n_read]) catch return error.WriteFailed;
-            total += n_read;
+        // 1. Send existing buffered data.
+        if (buffered.len > 0) {
+            p.socket.sendAll(buffered) catch return error.WriteFailed;
+            total_sent += buffered.len;
         }
 
-        return total;
+        // 2. Send the non-splat data slices.
+        for (data[0 .. data.len - 1]) |bytes| {
+            if (bytes.len > 0) {
+                p.socket.sendAll(bytes) catch return error.WriteFailed;
+                total_sent += bytes.len;
+            }
+        }
+
+        // 3. Send the last element (pattern) repeated `splat` times.
+        const pattern = data[data.len - 1];
+        if (pattern.len > 0) {
+            for (0..splat) |_| {
+                p.socket.sendAll(pattern) catch return error.WriteFailed;
+                total_sent += pattern.len;
+            }
+        }
+
+        return w.consume(total_sent);
     }
 
-    fn flush(_: *Io.Writer) Io.Writer.Error!void {
-        // No-op for blocking sockets.
+    fn sendFile(_: *Io.Writer, _: *std.fs.File.Reader, _: Io.Limit) Io.Writer.FileError!usize {
+        return error.Unimplemented;
+    }
+
+    fn flush(w: *Io.Writer) Io.Writer.Error!void {
+        return Io.Writer.defaultFlush(w);
     }
 
     fn rebase(_: *Io.Writer, _: usize, _: usize) Io.Writer.Error!void {

--- a/src/tls/tls.zig
+++ b/src/tls/tls.zig
@@ -159,10 +159,10 @@ pub const TlsSession = struct {
         const sock = self.socket orelse return error.MissingTransport;
 
         // Allocate buffers once per session.
-        if (self.net_read_buf == null) self.net_read_buf = try self.allocator.alloc(u8, 16 * 1024);
-        if (self.net_write_buf == null) self.net_write_buf = try self.allocator.alloc(u8, 16 * 1024);
-
         const min_tls_buf = tls.Client.min_buffer_len;
+        if (self.net_read_buf == null) self.net_read_buf = try self.allocator.alloc(u8, @max(16 * 1024, min_tls_buf));
+        if (self.net_write_buf == null) self.net_write_buf = try self.allocator.alloc(u8, @max(16 * 1024, min_tls_buf));
+
         if (self.tls_read_buf == null) self.tls_read_buf = try self.allocator.alloc(u8, min_tls_buf);
         if (self.tls_write_buf == null) self.tls_write_buf = try self.allocator.alloc(u8, min_tls_buf);
 
@@ -226,6 +226,14 @@ pub const TlsSession = struct {
     pub fn getWriter(self: *Self) !*std.Io.Writer {
         const c = if (self.client) |*c| c else return error.NotConnected;
         return &c.writer;
+    }
+
+    /// Flushes the TLS writer and the underlying network output writer.
+    /// Must be called after writing data to ensure it is actually sent.
+    pub fn flushWriter(self: *Self) !void {
+        const c = if (self.client) |*c| c else return error.NotConnected;
+        try c.writer.flush(); // Encrypt pending plaintext into output
+        try c.output.flush(); // Send encrypted data to socket
     }
 
     /// Returns the negotiated ALPN protocol.


### PR DESCRIPTION
I had Copilot help me make the json example in #4 work. This is what was needed for it to run. I'm new to Zig and just playing around, but may be this is helpful.

## Summary

This PR fixes multiple issues to make httpx.zig compile and work correctly on Windows with Zig 0.15.2. The changes address breaking API changes in Zig's standard library and fix critical bugs in the socket I/O and TLS layers that prevented HTTPS requests from succeeding.

## Changes

### build.zig
- Added `linkLibC()` on Windows for all build targets (examples, tests, benchmarks). This is required because `linkSystemLibrary("ws2_32")` and `linkSystemLibrary("mswsock")` need the C runtime to resolve Winsock symbols.

### src/net/address.zig
- Fixed `initIp6` call signature to match the Zig 0.15.2 API: `initIp6(ip6, port, 0, 0)` (previously `initIp6(ip6, 0, port)`).

### src/net/socket.zig
- **SocketIoReader.readVec**: Rewrote to use `writableVectorWsa` + `WSARecv` on Windows and `writableVector` + `recv` on POSIX. The previous implementation passed `bufs[0]` directly to `recv`, but the VTable contract allows callers to pass empty buffers (e.g., `&.{""}`) which caused false `EndOfStream` errors.
- **SocketIoReader.stream**: Simplified to use the fixed `readVec` via `writableSliceGreedy` + `advance` instead of a manual loop.
- **SocketIoReader**: Removed the `discard` vtable entry (no longer needed in Zig 0.15.2 I/O interface).
- **SocketIoWriter.drain**: Rewrote to properly send all buffered data using `sendAll` and `w.consume(total_sent)`. The previous implementation only sent the first non-empty slice and didn't call `consume()`, causing data loss.
- **SocketIoWriter.flush**: Changed from a no-op to delegate to `Io.Writer.defaultFlush`, which actually flushes buffered data to the socket.
- **SocketIoWriter.sendFile**: Stubbed out with `error.Unimplemented` (signature changed in Zig 0.15.2).

### src/tls/tls.zig
- Ensured TLS read/write buffers meet the minimum size required by `tls.Client.min_buffer_len` using `@max(16 * 1024, min_tls_buf)`.
- Added `flushWriter()` method that flushes both the TLS writer (encrypts pending plaintext) and the underlying output writer (sends encrypted data to the socket). Without this, data was encrypted but never actually transmitted.

### src/client/client.zig
- **`executeTlsHttp`**: Added `session.flushWriter()` call after writing request data, ensuring the TLS-encrypted request is actually sent over the wire.
- **`readResponseFromIo`**: Replaced direct `readVec` loop with `r.peek(1)` + buffer access pattern. The TLS reader decrypts into its internal buffer and may return 0 from `readVec`; using `peek` triggers decryption and then `r.buffer[r.seek..r.end]` accesses the decrypted data directly.
- Fixed `std.time.sleep` → `std.Thread.sleep` (API renamed in Zig 0.15.2).

### src/httpx.zig
- Exported `SocketIoReader` and `SocketIoWriter` from the public API.