### PR TITLE
fix: SocketIoReader.readVec handles Zig 0.15 fillUnbuffered empty-buf…

### DIFF
--- a/src/net/socket.zig
+++ b/src/net/socket.zig
@@ -148,6 +148,18 @@ pub const SocketIoReader = struct {
         const p = parent(r);
         if (bufs.len == 0) return 0;
         const buf = bufs[0];
+
+        // Zig 0.15 fillUnbuffered passes .{""} (empty buffer) to signal
+        // "fill the reader's own buffer instead". We must honor that.
+        if (buf.len == 0) {
+            const dest = r.buffer[r.end..];
+            if (dest.len == 0) return 0;
+            const n = p.socket.recv(dest) catch return error.ReadFailed;
+            if (n == 0) return error.EndOfStream;
+            r.end += n;
+            return 0;
+        }
+
         const n = p.socket.recv(buf) catch return error.ReadFailed;
         if (n == 0) return error.EndOfStream;
         return n;


### PR DESCRIPTION
…fer contract

Zig 0.15 changed fillUnbuffered to call readVec(r, &.{""}) — an array with one empty string — expecting the vtable readVec to fill r.buffer[r.end..] and update r.end. The old implementation only read into bufs[0] (the empty string), causing recv(buf) on a zero-length buffer to return 0, which was interpreted as EndOfStream → propagated as TlsConnectionTruncated in TLS init.

Now when bufs[0].len == 0 we read into the reader's own buffer at r.end and update r.end, matching the new contract.

Fixes #14

## Description

<!-- Please include a summary of the change and which issue is fixed. -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
