### PR TITLE
fix #14 & #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project are documented in this file.
 
 
+## [0.1.1] - 27-06-2026
+
+### Added
+- Added client-side forward proxy support (supporting HTTP/HTTPS proxies, custom proxy authentication, CONNECT tunnels for TLS/HTTP2, and absolute URLs for HTTP/1.x) for the request tracked in [Issue #15](https://github.com/muhammad-fiaz/httpx.zig/issues/15).
+- Added server-side reverse proxy middleware `reverseProxy(comptime target_url: []const u8)` to forward incoming requests to backends.
+- Added Zig 0.15 deprecation warnings in documentation.
+- Added three execution modes for client-side requests (`single_thread`, `multi_thread` with dynamic background workers, and `explicit_workers` using an existing thread pool).
+- Added `Server.listenInBackground()` to spin up the server event loop asynchronously in one call.
+- Added customizable logging support via `ServerConfig.log_fn` and `loggerWithConfig()` middleware to support integrating custom logging frameworks.
+
+### Changed
+- Bumped project version to `0.1.1`.
+- Cleaned up redundant and duplicate aliases to simplify the public API surface (removed type aliases `HttpClient`, `ReqOptions`, `HttpServer`, `Ctx`, utility function aliases `parseQueryValue`, `parseCookiePair`, `utils`, and client alias `httpOptions`).
+- Updated minimum Zig version to `0.16.0`.
+- Updated concurrent request functions (`all`, `allSettled`, `any`, `race`, `first`, `fastest`, `settled`) to accept a `ConcurrencyConfig`.
+- Aligned top-level package request wrappers (`get`, `getWithAllocator`, `fetch`, `fetchWithAllocator`) to accept `RequestOptions` for consistency with all other HTTP verb wrappers.
+- Expanded documentation coverage for client/server/network/protocol/sockets, proxy support, JSON helpers, logging callbacks, and the new `0.1.0` install path.
+
+### Fixed
+- Fixed HTTPS client TLS handshakes on Zig `0.16` by honoring `std.Io.Reader.fillUnbuffered`'s empty-buffer `readVec` contract in `src/net/socket.zig`, resolving `error.TlsConnectionTruncated` on simple GET requests. This addresses [Issue #14](https://github.com/muhammad-fiaz/httpx.zig/issues/14).
+- Fixed thread join hangs and socket/listener deinitialization sequence deadlocks in all runtime examples on scope exit.
+- Added comprehensive end-to-end runnable `proxy_example` demonstrating client forward proxying and server reverse proxy middleware.
+- Added unit tests for client-side proxy request formatting and base64 proxy authentication encoding.
+
 ## [0.1.0] - 18-04-2026
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@
 
 
 > [!WARNING]
-> `v0.1.0` is a major update from `0.0.7`.
-> It introduces built-in auth/content helpers, expanded top-level aliases, runtime/API refinements, and broader utility/docs coverage.
+> `v0.1.1` is the current release and targets Zig `0.16.0+`.
+> `v0.1.0` is the previous stable release for the immediate prior `0.1.x` line.
+> Zig `0.15` support is legacy and remains available only through `0.0.7`.
+> This release includes the HTTPS/TLS reader fix for Zig `0.16` empty-buffer reads that caused `error.TlsConnectionTruncated` on simple GET requests.
 > If you are migrating from `0.0.7`, review the changelog and refresh your install pin/hash before upgrading.
 
 
@@ -76,7 +78,10 @@
 | **Pre-Route and Global Handlers** | `preRoute(...)` hooks and `global(...)` fallback handlers for complete request lifecycle control. | https://muhammad-fiaz.github.io/httpx.zig/api/server |
 | **Unified Any-Method Routing** | `any(path, handler)` to register all standard HTTP methods on one endpoint. | https://muhammad-fiaz.github.io/httpx.zig/api/server |
 | **Concurrency** | Parallel request patterns (`race`, `all`, `any`) and async task execution. | https://muhammad-fiaz.github.io/httpx.zig/guide/concurrency |
+| **Socket APIs** | Cross-platform TCP/UDP socket helpers, listener wrappers, and TLS stream adapters. | https://muhammad-fiaz.github.io/httpx.zig/api/net |
+| **Proxy Support** | Client-side forward proxy routing and server-side reverse proxy middleware. | https://muhammad-fiaz.github.io/httpx.zig/examples/proxy-example |
 | **Interceptors** | Global hooks to modify requests and responses (e.g., Auth injection). | https://muhammad-fiaz.github.io/httpx.zig/guide/interceptors |
+| **Logging Hooks** | Server log callbacks plus logger middleware customization for structured output. | https://muhammad-fiaz.github.io/httpx.zig/api/middleware |
 | **Smart Retries** | Configurable retry policies with exponential backoff. | https://muhammad-fiaz.github.io/httpx.zig/api/client |
 | **Config Builder Helpers** | Chainable optional customization helpers for `ClientConfig` and `RequestOptions` (defaults remain implicit). | https://muhammad-fiaz.github.io/httpx.zig/api/client |
 | **JSON and HTML** | Helpers for easy JSON serialization and HTML response generation. | https://muhammad-fiaz.github.io/httpx.zig/api/core |
@@ -143,38 +148,49 @@ zig build -Dtarget=x86-windows
 
 ## Installation
 
-### Method 1: Zig Fetch (Latest Release 0.1.0)
+### Method 1: Zig Fetch (Latest Release 0.1.1)
+
+```bash
+zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz
+```
+
+### Method 2: Zig Fetch (Previous Stable 0.1.0)
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz
 ```
 
-### Method 2: Zig Fetch (Previous Stable 0.0.7)
+### Method 3: Zig Fetch (Legacy Zig 0.15 Support - 0.0.7)
+
+For Zig version 0.15 support, use this version:
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.0.7.tar.gz
 ```
 
-### Method 3: Zig Fetch (Nightly/Main)
+> [!WARNING]
+> Zig `0.15` is deprecated. It uses an older API surface and is only retained in `0.0.7`.
+
+### Method 4: Zig Fetch (Nightly/Main)
 
 ```bash
 zig fetch --save git+https://github.com/muhammad-fiaz/httpx.zig.git
 ```
 
-### Method 4: Manual `build.zig.zon` Configuration
+### Method 5: Manual `build.zig.zon` Configuration
 
 Add this dependency entry to your `build.zig.zon`:
 
 ```zig
 .dependencies = .{
     .httpx = .{
-        .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz",
+        .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz",
         .hash = "...", // Run zig fetch --save <url> to auto-fill this.
     },
 },
 ```
 
-### Method 5: Local Source Checkout
+### Method 6: Local Source Checkout
 
 ```bash
 git clone https://github.com/muhammad-fiaz/httpx.zig.git
@@ -304,7 +320,7 @@ const specs = [_]httpx.RequestSpec{
 var client_for_concurrency = httpx.Client.init(allocator);
 defer client_for_concurrency.deinit();
 
-var all_results = try httpx.all(allocator, &client_for_concurrency, &specs);
+var all_results = try httpx.all(allocator, &client_for_concurrency, &specs, .{});
 defer {
     for (all_results) |*r| r.deinit();
     allocator.free(all_results);
@@ -315,7 +331,7 @@ const err_count = httpx.errorCount(all_results);
 _ = ok_count;
 _ = err_count;
 
-var first_ok = try httpx.first(allocator, &client_for_concurrency, &specs);
+var first_ok = try httpx.first(allocator, &client_for_concurrency, &specs, .{});
 if (first_ok) |*resp| resp.deinit();
 ```
  

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,10 +7,10 @@ supported with security updates.
 
 | Version  | Supported |
 | -------- | --------- |
-| 0.1.0    | :white_check_mark: |
-| < 0.1.0  | :x: |
+| 0.1.1    | :white_check_mark: |
+| < 0.1.1  | :x: |
 
-Versions below 0.1.0 are considered end-of-life and will not receive
+Versions below 0.1.1 are considered end-of-life and will not receive
 security fixes or updates.
 
 ---
@@ -59,7 +59,7 @@ When reporting a vulnerability, please include:
   - Credit will be given upon request
 
 - Declined:
-  - Issues affecting unsupported versions (< 0.1.0)
+  - Issues affecting unsupported versions (< 0.1.1)
   - Expected or documented behavior
   - Issues already fixed in a newer release
 

--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
         .{ .name = "interceptors", .path = "examples/interceptors.zig" },
         .{ .name = "connection_pool", .path = "examples/connection_pool.zig" },
         .{ .name = "cookies_demo", .path = "examples/cookies_demo.zig" },
+        .{ .name = "proxy_example", .path = "examples/proxy_example.zig" },
         .{ .name = "simplified_api_aliases", .path = "examples/simplified_api_aliases.zig" },
         .{ .name = "static_files", .path = "examples/static_files.zig", .skip_run_all = true },
         .{ .name = "multi_page_website", .path = "examples/multi_page_website.zig", .skip_run_all = true },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa924bc2e7af6a8f2,
     .name = .httpx,
-    .version = "0.1.0",
+    .version = "0.1.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -52,6 +52,7 @@ export default defineConfig({
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
     ["meta", { property: "og:image:alt", content: "httpx.zig - High Performance Zig HTTP Library" }],
+    ["meta", { property: "og:image:secure_url", content: `${SITE_URL}/cover.png` }],
     ["meta", { property: "og:site_name", content: SITE_NAME }],
     ["meta", { property: "og:locale", content: "en_US" }],
 
@@ -61,6 +62,8 @@ export default defineConfig({
     ["meta", { name: "twitter:title", content: SITE_NAME }],
     ["meta", { name: "twitter:description", content: SITE_DESCRIPTION }],
     ["meta", { name: "twitter:image", content: `${SITE_URL}/cover.png` }],
+    ["meta", { name: "twitter:image:alt", content: "httpx.zig - High Performance Zig HTTP Library" }],
+    ["meta", { name: "twitter:site", content: "@muhammadfiaz_" }],
     ["meta", { name: "twitter:creator", content: "@muhammadfiaz_" }],
 
     // Canonical URL
@@ -338,6 +341,7 @@ gtag('config', '${GA_ID}');`,
           { text: "Connection Pool", link: "/examples/connection-pool" },
           { text: "Interceptors", link: "/examples/interceptors" },
           { text: "Cookies Demo", link: "/examples/cookies-demo" },
+          { text: "Proxy Example", link: "/examples/proxy-example" },
           { text: "Simplified API Aliases", link: "/examples/simplified-api-aliases" },
           { text: "Simple Server", link: "/examples/simple-server" },
           { text: "Router Example", link: "/examples/router-example" },

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -66,7 +66,7 @@ defer client.deinit();
 | `retry_policy` | `RetryPolicy` | `{}` | Configuration for automatic retries. |
 | `redirect_policy` | `RedirectPolicy` | `{}` | Configuration for handling redirects. |
 | `default_headers` | `?[]const [2][]const u8` | `null` | Headers added to every request. |
-| `user_agent` | `[]const u8` | `"httpx.zig/0.1.0"` | User-Agent header value. |
+| `user_agent` | `[]const u8` | `"httpx.zig/0.1.1"` | User-Agent header value. |
 | `max_response_size` | `usize` | `100MB` | Maximum allowed response body size. |
 | `follow_redirects` | `bool` | `true` | Whether to automatically follow redirects. |
 | `verify_ssl` | `bool` | `true` | Whether to verify SSL certificates. |
@@ -77,6 +77,7 @@ defer client.deinit();
 | `keep_alive` | `bool` | `true` | Reuse TCP connections when possible. |
 | `pool_max_connections` | `u32` | `20` | Maximum connections in the pool. |
 | `pool_max_per_host` | `u32` | `5` | Maximum connections to a single host. |
+| `proxy` | `?Proxy` | `null` | Optional forward proxy configuration for client requests. |
 
 If you do not set a field, the implicit default value is used. Builder helpers only override the fields you call.
 
@@ -100,6 +101,7 @@ If you do not set a field, the implicit default value is used. Builder helpers o
 | `withKeepAlive(enabled)` | Toggle keep-alive connection reuse. |
 | `withMaxResponseSize(bytes)` | Override maximum response body size. |
 | `withPoolLimits(max_connections, max_per_host)` | Override pool sizing limits. |
+| `withProxy(proxy_or_null)` | Configure or clear a forward proxy. |
 
 ### Client Initialization Helpers
 
@@ -148,8 +150,7 @@ pub fn opts(self: *Self, url: []const u8, options: RequestOptions) !Response
 | `head(url, options)` | HTTP HEAD request |
 | `trace(url, options)` | HTTP TRACE request |
 | `connect(url, options)` | HTTP CONNECT request |
-| `httpOptions(url, options)` | HTTP OPTIONS request |
-| `options(url, options)` | Alias for HTTP OPTIONS request |
+| `options(url, options)` | HTTP OPTIONS request |
 | `opts(url, options)` | Alias for HTTP OPTIONS request |
 | `send(method, url, options)` | Alias for generic request |
 | `addInterceptor(interceptor)` | Add request/response interceptor |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -94,3 +94,12 @@ The root module re-exports core types and convenience helpers so most apps can i
 - HTTP/2 has high-level client and server runtime paths plus full protocol primitives (HPACK/framing/streams).
 - HTTP/3 has high-level client and server runtime paths over UDP/QUIC stream framing, plus full protocol primitives (QPACK/HTTP3/QUIC framing).
 - Cross-platform validation is maintained for Linux/Windows (x86, x86_64, aarch64) and macOS (x86_64, aarch64) build matrices.
+
+## Customization and Callbacks
+
+- Client interceptors for request/response hooks: `addInterceptor(...)`
+- Server logging sinks via `ServerConfig.log_fn`
+- Middleware logger customization via `loggerWithConfig(.{ .log_fn = ... })`
+- Request and response JSON helpers: `RequestOptions.withJson(...)`, `Response.json(T)`
+- Socket and UDP primitives: `Socket`, `UdpSocket`, `SocketIoReader`, `SocketIoWriter`
+- Custom middleware structs with `handler` functions

--- a/docs/api/middleware.md
+++ b/docs/api/middleware.md
@@ -20,11 +20,31 @@ try server.use(httpx.middleware.cors(.{}));
 
 ### `logger`
 
-Logs request method, path, and detailed timing information to `std.debug`.
+Logs request method, path, and detailed timing information to `std.debug` by default.
 
 ```zig
 server.use(httpx.middleware.logger());
 ```
+
+To route logs into your own sink, use `loggerWithConfig`:
+
+```zig
+const httpx = @import("httpx");
+const std = @import("std");
+const allocator = std.heap.page_allocator;
+
+var server = httpx.Server.init(allocator);
+const CustomLogger = struct {
+    fn log(level: httpx.LogLevel, message: []const u8) void {
+        _ = level;
+        std.debug.print("{s}", .{message});
+    }
+};
+
+server.use(httpx.middleware.loggerWithConfig(.{ .log_fn = CustomLogger.log }));
+```
+
+To disable request logging, simply do not install the logger middleware.
 
 ### `cors`
 

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -52,6 +52,7 @@ var server = httpx.Server.initWithConfig(allocator, .{
 | `http3_enabled` | `bool` | `false` | Enable HTTP/3 server runtime path (UDP transport). |
 | `http2_settings` | `Http2Settings` | `{}` | HTTP/2 SETTINGS frame defaults and limits. |
 | `http3_settings` | `Http3Settings` | `{}` | HTTP/3 SETTINGS defaults (QPACK/field section limits). |
+| `log_fn` | `?LogFn` | `null` | Optional server log callback. Leave unset to disable server-side logging output. |
 
 All `ServerConfig` fields are optional customizations. Omitted fields use the built-in defaults.
 
@@ -122,6 +123,30 @@ Adds a middleware to the global stack.
 ```zig
 try server.use(httpx.middleware.logger());
 ```
+
+### Logging
+
+Server-side logging is opt-in. You can attach a custom log sink with `ServerConfig.log_fn`, or skip the logger middleware entirely to disable request logs.
+
+```zig
+const std = @import("std");
+const httpx = @import("httpx");
+const allocator = std.heap.page_allocator;
+
+const CustomLogger = struct {
+    fn log(level: httpx.LogLevel, message: []const u8) void {
+        std.debug.print("[{s}] {s}", .{ @tagName(level), message });
+    }
+};
+
+var server = httpx.Server.initWithConfig(allocator, .{
+    .log_fn = CustomLogger.log,
+});
+
+try server.use(httpx.middleware.loggerWithConfig(.{ .log_fn = CustomLogger.log }));
+```
+
+If you want no request logging, omit `httpx.middleware.logger()` and leave `log_fn = null`.
 
 ### Routing Methods
 

--- a/docs/examples/concurrent-requests.md
+++ b/docs/examples/concurrent-requests.md
@@ -1,6 +1,6 @@
 # Concurrent Requests
 
-Execute many requests in parallel with shared client configuration.
+Execute multiple requests in parallel using dynamic thread workers, sequential execution, or explicit executors.
 
 ## Demo Program
 
@@ -8,30 +8,83 @@ Execute many requests in parallel with shared client configuration.
 const std = @import("std");
 const httpx = @import("httpx");
 
+fn mockHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.text("Hello!");
+}
+
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var client = httpx.Client.init(allocator);
+    // 1. Start a local loopback server
+    var server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = 45235,
+        .keep_alive = false,
+    });
+    defer server.deinit();
+    try server.get("/data", mockHandler);
+
+    const server_thread = try std.Thread.spawn(.{}, struct {
+        fn run(s: *httpx.Server) void {
+            s.listen() catch {};
+        }
+    }.run, .{&server});
+    defer server_thread.join();
+    defer server.stop();
+
+    std.time.sleep(20 * std.time.ns_per_ms);
+
+    // 2. Build a batch of request specifications
+    var builder = httpx.concurrency.BatchBuilder.init(allocator);
+    defer builder.deinit();
+
+    _ = try builder.get("http://127.0.0.1:45235/data");
+    _ = try builder.get("http://127.0.0.1:45235/data");
+    _ = try builder.get("http://127.0.0.1:45235/data");
+
+    var client = httpx.Client.initWithConfig(allocator, .{});
     defer client.deinit();
 
-    const urls = [_][]const u8{
-        "https://httpbin.org/get?a=1",
-        "https://httpbin.org/get?a=2",
-        "https://httpbin.org/get?a=3",
-    };
-
-    var responses: [urls.len]httpx.Response = undefined;
-    defer for (responses) |*r| r.deinit();
-
-    for (urls, 0..) |url, i| {
-        responses[i] = try client.get(url, .{});
+    // 3. Multi-threaded Mode (with at most 2 concurrent workers)
+    std.debug.print("Executing with multi_thread mode (2 workers)...\n", .{});
+    const mt_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .multi_thread,
+        .workers = 2,
+    });
+    defer {
+        for (mt_results) |*r| r.deinit();
+        allocator.free(mt_results);
     }
+    std.debug.print("Success: {d}/{d}\n\n", .{ httpx.successfulCount(mt_results), mt_results.len });
 
-    for (responses, 0..) |r, i| {
-        std.debug.print("req {d}: status={d}\n", .{ i, r.status.code });
+    // 4. Single-threaded Mode (sequentially on calling thread)
+    std.debug.print("Executing with single_thread mode (sequential)...\n", .{});
+    const st_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .single_thread,
+    });
+    defer {
+        for (st_results) |*r| r.deinit();
+        allocator.free(st_results);
     }
+    std.debug.print("Success: {d}/{d}\n\n", .{ httpx.successfulCount(st_results), st_results.len });
+
+    // 5. Explicit Workers Mode (reusing a started Executor)
+    std.debug.print("Executing with explicit_workers mode...\n", .{});
+    var exec = httpx.Executor.initWithConfig(allocator, .{ .num_threads = 3 });
+    defer exec.deinit();
+    try exec.start();
+
+    const ex_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .explicit_workers,
+        .executor = &exec,
+    });
+    defer {
+        for (ex_results) |*r| r.deinit();
+        allocator.free(ex_results);
+    }
+    std.debug.print("Success: {d}/{d}\n\n", .{ httpx.successfulCount(ex_results), ex_results.len });
 }
 ```
 
@@ -43,5 +96,6 @@ zig build run-concurrent_requests
 
 ## What to Verify
 
-- All requests return successful status codes.
-- Responses are handled independently without shared-state corruption.
+- Request batch executes successfully across all three execution modes.
+- Parallel worker counts can be configured dynamically using `ConcurrencyConfig`.
+- Custom thread pools/executors are supported for explicit worker execution.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -27,6 +27,7 @@ zig build example-http3_example -Dtarget=aarch64-macos
 - [Connection Pool](/examples/connection-pool): Reuse pooled connections efficiently.
 - [Interceptors](/examples/interceptors): Apply request and response interceptors.
 - [Cookies Demo](/examples/cookies-demo): Manage cookie jar values in client flows.
+- [Proxy and Reverse Proxy](/examples/proxy-example): Configure client forward proxies and register reverse proxy middleware.
 - [Simplified API Aliases](/examples/simplified-api-aliases): Use short top-level helper APIs with local loopback success mode by default.
 - [Simple Server](/examples/simple-server): Start a minimal HTTP server.
 - [Router Example](/examples/router-example): Route params and grouped endpoints.

--- a/docs/examples/middleware-example.md
+++ b/docs/examples/middleware-example.md
@@ -19,6 +19,10 @@ fn secure(ctx: *httpx.Context) anyerror!httpx.Response {
     return ctx.json(.{ .message = "secure route" });
 }
 
+fn logMessage(level: httpx.LogLevel, message: []const u8) void {
+    std.debug.print("[{s}] {s}", .{ @tagName(level), message });
+}
+
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
@@ -27,7 +31,7 @@ pub fn main() !void {
     var server = httpx.Server.init(allocator);
     defer server.deinit();
 
-    try server.use(httpx.logger());
+    try server.use(httpx.middleware.loggerWithConfig(.{ .log_fn = logMessage }));
     try server.use(httpx.cors(.{}));
     try server.use(.{ .name = "auth", .handler = auth });
 

--- a/docs/examples/proxy-example.md
+++ b/docs/examples/proxy-example.md
@@ -1,0 +1,93 @@
+# Proxy and Reverse Proxy
+
+Demonstrates how to use client-side forward proxying and server-side reverse proxying.
+
+## Demo Program
+
+```zig
+const std = @import("std");
+const httpx = @import("httpx");
+
+fn mockBackendHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.text("Hello from Mock Backend!");
+}
+
+pub fn main() !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const backend_port = 45233;
+    const proxy_port = 45234;
+
+    // 1. Start the mock backend server
+    var backend_server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = backend_port,
+        .keep_alive = false,
+    });
+    defer backend_server.deinit();
+    try backend_server.get("/backend-data", mockBackendHandler);
+
+    const backend_thread = try std.Thread.spawn(.{}, struct {
+        fn run(server: *httpx.Server) void {
+            server.listen() catch {};
+        }
+    }.run, .{&backend_server});
+    defer backend_thread.join();
+    defer backend_server.stop();
+
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.sleep(io, std.Io.Duration.fromMilliseconds(20), .real) catch {};
+
+    // 2. Start the proxy server with reverseProxy middleware
+    var proxy_server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = proxy_port,
+        .keep_alive = false,
+    });
+    defer proxy_server.deinit();
+
+    try proxy_server.use(httpx.reverseProxy("http://127.0.0.1:45233"));
+
+    const proxy_thread = try std.Thread.spawn(.{}, struct {
+        fn run(server: *httpx.Server) void {
+            server.listen() catch {};
+        }
+    }.run, .{&proxy_server});
+    defer proxy_thread.join();
+    defer proxy_server.stop();
+
+    std.Io.sleep(io, std.Io.Duration.fromMilliseconds(20), .real) catch {};
+
+    // 3. Setup client with proxy configuration pointing to the proxy server
+    const client_config = httpx.ClientConfig.defaults()
+        .withProxy(.{
+            .host = "127.0.0.1",
+            .port = proxy_port,
+        });
+
+    var client = httpx.Client.initWithConfig(allocator, client_config);
+    defer client.deinit();
+
+    // 4. Request the mock backend path through the proxy.
+    const target_url = "http://127.0.0.1:45233/backend-data";
+    var response = try client.get(target_url, .{});
+    defer response.deinit();
+
+    std.debug.print("Proxy response status: {d}\n", .{response.status.code});
+    std.debug.print("Proxy response body: {s}\n", .{response.text() orelse ""});
+}
+```
+
+## Run
+
+```bash
+zig build run-proxy_example
+```
+
+## What to Verify
+
+- Client requests are intercepted and successfully routed through the proxy server.
+- The reverse proxy middleware forwards the request to the target mock backend server.
+- Response body text returned matches the mock backend response.

--- a/docs/examples/request-response-customization.md
+++ b/docs/examples/request-response-customization.md
@@ -1,0 +1,31 @@
+# Request and Response Customization
+
+This demo shows the full request/response customization surface that is already implemented in `httpx.zig`:
+
+- Request builders and direct request mutation
+- Query params, headers, bearer auth, and JSON bodies
+- Response accessors for status, headers, content type, content length, location, and body text
+- Server-side request inspection with `Context` helpers
+- Redirects and HTML/JSON responses
+
+## Demo Program
+
+```zig
+const std = @import("std");
+const httpx = @import("httpx");
+
+// See examples/request_response_customization.zig
+```
+
+## Run
+
+```bash
+zig build run-request_response_customization
+```
+
+## What to Verify
+
+- Direct request serialization includes custom headers, query params, and auth.
+- RequestBuilder can build JSON requests with explicit protocol versions.
+- The server sees query params, headers, body text, and auth values.
+- Response accessors return the expected content type, content length, redirect location, and text body.

--- a/docs/guide/client-basics.md
+++ b/docs/guide/client-basics.md
@@ -138,7 +138,7 @@ client.clearCookies();
 For top-level convenience in smaller programs, use aliases from the root module:
 
 ```zig
-var res = try httpx.fetch("https://httpbin.org/get");
+var res = try httpx.fetch("https://httpbin.org/get", .{});
 defer res.deinit();
 
 var custom = try httpx.send(.GET, "https://httpbin.org/headers", .{});
@@ -189,6 +189,23 @@ pub const RequestOptions = struct {
 ```
 
 All fields are optional customizations. Passing `.{}` keeps defaults implicit.
+
+## Proxy Configuration
+
+Configure forward proxies when initializing the client:
+
+```zig
+const config = httpx.ClientConfig.defaults()
+    .withProxy(.{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .username = "user",  // Optional authentication
+        .password = "pass",  // Optional authentication
+    });
+
+var client = httpx.Client.initWithConfig(allocator, config);
+defer client.deinit();
+```
 
 ## Response Handling
 

--- a/docs/guide/concurrency.md
+++ b/docs/guide/concurrency.md
@@ -2,6 +2,33 @@
 
 `httpx.zig` provides robust primitives for concurrent execution and background task management.
 
+The concurrency model is intentionally explicit:
+1. **Single-Threaded**: Runs requests sequentially on the calling thread, with zero extra worker threads.
+2. **Multi-Threaded**: Runs requests concurrently on a configurable pool of background request workers.
+3. **Explicit Workers**: Runs requests concurrently by reusing an explicitly provided `Executor` thread pool.
+
+When configuration is omitted, sensible defaults are used. The library derives worker counts from the host CPU when appropriate, while keeping the final values visible on the config objects so explicit overrides always win.
+
+## Configuration Options
+
+Configure concurrent request execution using `ConcurrencyConfig`:
+
+```zig
+pub const ConcurrencyMode = enum {
+    single_thread,
+    multi_thread,
+    explicit_workers,
+};
+
+pub const ConcurrencyConfig = struct {
+    mode: ConcurrencyMode = .multi_thread,
+    workers: ?u32 = null, // Number of background thread workers (multi_thread mode)
+    executor: ?*Executor = null, // Explicit executor instance (explicit_workers mode)
+};
+```
+
+`ConcurrencyConfig` currently exposes request worker selection only. CPU affinity and per-thread pinning are not exposed as public APIs, so portable defaults remain the recommended path.
+
 ## Parallel Requests
 
 Execute multiple HTTP requests simultaneously using the helpful wrapper functions.
@@ -19,8 +46,8 @@ defer builder.deinit();
 try builder.get("https://site-a.com");
 try builder.post("https://site-b.com", body);
 
-// Execute all
-const results = try httpx.concurrency.all(allocator, &client, builder.requests.items);
+// Execute all using the default multi-threaded worker pool
+const results = try httpx.concurrency.all(allocator, &client, builder.requests.items, .{});
 defer allocator.free(results);
 
 for (results) |res| {
@@ -32,12 +59,27 @@ for (results) |res| {
 }
 ```
 
+To limit execution to at most 2 threads:
+```zig
+const results = try httpx.concurrency.all(allocator, &client, specs, .{
+    .mode = .multi_thread,
+    .workers = 2,
+});
+```
+
+To execute sequentially on the calling thread (no background threads):
+```zig
+const results = try httpx.concurrency.all(allocator, &client, specs, .{
+    .mode = .single_thread,
+});
+```
+
 ### `race`
 
 Returns the result of the **first** request to complete (success or failure).
 
 ```zig
-const result = try httpx.concurrency.race(allocator, &client, specs);
+const result = try httpx.concurrency.race(allocator, &client, specs, .{});
 if (result.isSuccess()) {
     // ...
 }
@@ -45,17 +87,25 @@ if (result.isSuccess()) {
 
 ### `any`
 
-Returns the **first successful** (2xx) response.
+Returns the **first successful** (2xx) response. Other workers check the winner atomic and bail out early, preventing unnecessary network calls once a response is resolved.
 
 ```zig
-if (try httpx.concurrency.any(allocator, &client, specs)) |success_response| {
+if (try httpx.concurrency.any(allocator, &client, specs, .{})) |success_response| {
     // ...
 }
 ```
 
+---
+
 ## Task Executor
 
 The `Executor` provides a thread pool for running background tasks, useful for offloading heavy work from the main request thread in a server environment.
+
+### Executor Defaults
+
+- `num_threads = 0` means "choose a sensible default from the host CPU count".
+- `task_queue_size = 1024` bounds pending tasks before submission fails.
+- `idle_timeout_ms = 60_000` is the default idle timeout used by higher-level schedulers.
 
 ### Initialization
 
@@ -82,12 +132,13 @@ var data = MyData{ .val = 123 };
 try exec.execute(heavyWork, &data);
 ```
 
-### Configuration
+### Using Executor as Explicit Concurrency Workers
+
+You can pass the `Executor` directly to concurrent request calls:
 
 ```zig
-const config = httpx.executor.ExecutorConfig{
-    .num_threads = 4,
-    .task_queue_size = 2048,
-};
-var exec = httpx.executor.Executor.initWithConfig(allocator, config);
+const results = try httpx.concurrency.all(allocator, &client, specs, .{
+    .mode = .explicit_workers,
+    .executor = &exec,
+});
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -30,8 +30,12 @@ Zig's standard library does not provide HTTP/2, HTTP/3, or QUIC support. **httpx
 - **Zig Version**: 0.16.0 or later
 - **Operating System**: Windows, Linux, or macOS
 
-::: warning v0.1.0 major update from 0.0.7
-If you are upgrading from `0.0.7`, treat `v0.1.0` as a major update and review `/CHANGELOG` before migration.
+::: warning v0.1.1 release and Zig 0.15 deprecation
+`v0.1.1` is the current release and targets Zig `0.16.0+`.
+`v0.1.0` is the previous stable release for the immediate prior `0.1.x` line.
+Zig `0.15` support is legacy and remains available only through `0.0.7`.
+The HTTPS/TLS reader fix for Zig `0.16` empty-buffer reads is included in this release.
+If you are upgrading from `0.0.7`, review `/CHANGELOG` before migration.
 :::
 
 ## Platform Support

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -7,9 +7,12 @@ This guide covers all supported installation methods for `httpx.zig`.
 - **Zig Version**: 0.16.0 or later
 - **Operating System**: Windows, Linux, or macOS
 
-::: warning v0.1.0 major update from 0.0.7
-`v0.1.0` is a major update from `0.0.7`.
-If you are migrating an existing project, review `/CHANGELOG` and refresh dependency pin/hash values before building.
+::: warning v0.1.1 release and Zig 0.15 deprecation
+`v0.1.1` is the current release and targets Zig `0.16.0+`.
+`v0.1.0` is the previous stable release for the immediate prior `0.1.x` line.
+Zig `0.15` support is legacy and remains available only through `0.0.7`.
+The HTTPS/TLS reader fix for Zig `0.16` empty-buffer reads is included in this release.
+If you are upgrading from `0.0.7`, review `/CHANGELOG` first and refresh your dependency pin/hash.
 :::
 
 ## Platform Support
@@ -46,23 +49,35 @@ zig build -Dtarget=aarch64-macos
 ```
 :::
 
-## Method 1: Zig Fetch (Latest Release 0.1.0)
+## Method 1: Zig Fetch (Latest Release 0.1.1)
 
 Use the latest tagged release for reproducible builds:
+
+```bash
+zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz
+```
+
+## Method 2: Zig Fetch (Previous Stable 0.1.0)
+
+Use the previous stable `0.1.0` release if you want the last `0.1.x` tag before `0.1.1`:
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz
 ```
 
-## Method 2: Zig Fetch (Previous Stable 0.0.7)
+## Method 3: Zig Fetch (Legacy Zig 0.15 Support - 0.0.7)
 
-Use the previous stable tag when you need to pin to the prior release:
+For Zig version 0.15 support, use this version:
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.0.7.tar.gz
 ```
 
-## Method 3: Zig Fetch (Nightly/Main)
+::: warning Zig 0.15 deprecation
+Zig `0.15` support is deprecated; use `0.0.7` if you need the older API surface.
+:::
+
+## Method 4: Zig Fetch (Nightly/Main)
 
 Use the Git URL if you want the latest commits from main:
 
@@ -70,17 +85,17 @@ Use the Git URL if you want the latest commits from main:
 zig fetch --save git+https://github.com/muhammad-fiaz/httpx.zig.git
 ```
 
-## Method 4: Manual `build.zig.zon` Configuration
+## Method 5: Manual `build.zig.zon` Configuration
 
 You can also add the dependency manually:
 
 ```zig
 .{
     .name = "my-project",
-    .version = "0.1.0",
+    .version = "0.1.1",
     .dependencies = .{
         .httpx = .{
-            .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz",
+            .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz",
             .hash = "...", // Run zig fetch --save <url> to auto-fill this.
         },
     },
@@ -90,7 +105,7 @@ You can also add the dependency manually:
 }
 ```
 
-## Method 5: Local Source Checkout
+## Method 6: Local Source Checkout
 
 Clone and build directly:
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -17,6 +17,8 @@ try server.use(httpx.middleware.rateLimit(.{
 }));
 ```
 
+Logging is opt-in. Use `httpx.middleware.loggerWithConfig(.{ .log_fn = ... })` to send logs to a custom sink, or omit the logger middleware to disable request logging.
+
 ## Built-in Middleware
 
 `httpx.zig` includes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,37 +38,50 @@ features:
 
 ## Install
 
-::: warning v0.1.0 major update from 0.0.7
-`v0.1.0` is a major update from `0.0.7` (built-in auth/content helpers, expanded alias coverage, runtime/API updates, and docs refresh).
+::: warning v0.1.1 release and Zig 0.15 deprecation
+`v0.1.1` is the current release and targets Zig `0.16.0+`.
+`v0.1.0` is the previous stable release for the immediate prior `0.1.x` line.
+Zig `0.15` support is legacy and remains available only through `0.0.7`.
+The HTTPS/TLS reader fix for Zig `0.16` empty-buffer reads is included in this release.
 If you are upgrading from `0.0.7`, review `/CHANGELOG` first and refresh your dependency pin/hash.
 :::
 
 Choose one of these installation methods:
 
-1. Latest release (0.1.0)
+1. Latest release (0.1.1)
+
+```bash
+zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz
+```
+
+2. Previous stable release (0.1.0)
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz
 ```
 
-2. Previous stable release (0.0.7)
+3. Legacy Zig 0.15 support (0.0.7)
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.0.7.tar.gz
 ```
 
-3. Nightly/main branch
+::: warning Zig 0.15 deprecation
+Zig `0.15` is deprecated. It uses an older API surface and is only retained in `0.0.7`.
+:::
+
+4. Nightly/main branch
 
 ```bash
 zig fetch --save git+https://github.com/muhammad-fiaz/httpx.zig
 ```
 
-4. Manual dependency entry in `build.zig.zon`
+5. Manual dependency entry in `build.zig.zon`
 
 ```zig
 .dependencies = .{
   .httpx = .{
-    .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.0.tar.gz",
+    .url = "https://github.com/muhammad-fiaz/httpx.zig/archive/refs/tags/0.1.1.tar.gz",
     .hash = "...",
   },
 },

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "httpx-zig-docs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Documentation for httpx.zig",
   "scripts": {
     "docs:dev": "vitepress dev",

--- a/examples/concurrent_requests.zig
+++ b/examples/concurrent_requests.zig
@@ -1,9 +1,20 @@
 //! Concurrent Requests Example
 //!
-//! Demonstrates executing multiple HTTP requests in parallel.
+//! Demonstrates:
+//! 1. Running concurrent HTTP requests in parallel using different concurrency modes.
+//! 2. Single-threaded, Multi-threaded, and Explicit Executor workers.
 
 const std = @import("std");
 const httpx = @import("httpx");
+
+fn sleepMs(ms: i64) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.sleep(io, std.Io.Duration.fromMilliseconds(ms), .real) catch {};
+}
+
+fn helloHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.text("Hello!");
+}
 
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
@@ -12,33 +23,72 @@ pub fn main() !void {
 
     std.debug.print("=== Concurrent Requests Example ===\n\n", .{});
 
+    const port = 45235;
+
+    // 1. Start a local loopback mock server
+    var server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = port,
+        .keep_alive = false,
+    });
+    defer server.deinit();
+    try server.get("/data", helloHandler);
+
+    const server_thread = try server.listenInBackground();
+    defer server_thread.join();
+    defer server.stop();
+
+    sleepMs(20);
+
+    // 2. Build a batch of requests
     var builder = httpx.concurrency.BatchBuilder.init(allocator);
     defer builder.deinit();
 
-    _ = try builder.get("https://httpbin.org/get");
-    _ = try builder.get("https://httpbin.org/delay/1");
-    _ = try builder.get("https://httpbin.org/headers");
-    _ = try builder.post("https://httpbin.org/post", "{\"event\":\"page_view\"}");
+    _ = try builder.get("http://127.0.0.1:45235/data");
+    _ = try builder.get("http://127.0.0.1:45235/data");
+    _ = try builder.get("http://127.0.0.1:45235/data");
 
-    std.debug.print("Batch contains {d} requests:\n", .{builder.count()});
-    for (builder.requests.items, 0..) |req, i| {
-        std.debug.print("  {d}. {s} {s}\n", .{ i + 1, req.method.toString(), req.url });
+    var client = httpx.Client.initWithConfig(allocator, .{});
+    defer client.deinit();
+
+    // 3. Mode: multi_thread (implicit background workers)
+    std.debug.print("Executing batch of {d} requests via multi_thread mode (implicit workers)...\n", .{builder.count()});
+    const mt_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .multi_thread,
+        .workers = 2,
+    });
+    defer {
+        for (mt_results) |*r| r.deinit();
+        allocator.free(mt_results);
     }
+    std.debug.print("Successful results: {d}/{d}\n\n", .{ httpx.successfulCount(mt_results), mt_results.len });
 
-    std.debug.print("\nRequest specifications:\n", .{});
-    const specs = [_]httpx.concurrency.RequestSpec{
-        .{ .method = .GET, .url = "https://api1.example.com/data" },
-        .{ .method = .GET, .url = "https://api2.example.com/data" },
-        .{ .method = .POST, .url = "https://api3.example.com/data", .body = "{}" },
-    };
-
-    for (specs, 0..) |spec, i| {
-        std.debug.print("  Spec {d}: {s} {s}", .{ i + 1, spec.method.toString(), spec.url });
-        if (spec.body) |body| {
-            std.debug.print(" (body: {d} bytes)", .{body.len});
-        }
-        std.debug.print("\n", .{});
+    // 4. Mode: single_thread (sequential execution on calling thread)
+    std.debug.print("Executing batch of {d} requests via single_thread mode (sequential)...\n", .{builder.count()});
+    const st_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .single_thread,
+    });
+    defer {
+        for (st_results) |*r| r.deinit();
+        allocator.free(st_results);
     }
+    std.debug.print("Successful results: {d}/{d}\n\n", .{ httpx.successfulCount(st_results), st_results.len });
 
-    std.debug.print("\nDemo complete! (Network requests skipped for offline demo)\n", .{});
+    // 5. Mode: explicit_workers (explicit Executor thread pool)
+    std.debug.print("Executing batch of {d} requests via explicit_workers mode...\n", .{builder.count()});
+    var exec = httpx.Executor.initWithConfig(allocator, .{ .num_threads = 3 });
+    defer exec.deinit();
+    try exec.start();
+
+    const ex_results = try httpx.all(allocator, &client, builder.requests.items, .{
+        .mode = .explicit_workers,
+        .executor = &exec,
+    });
+    defer {
+        for (ex_results) |*r| r.deinit();
+        allocator.free(ex_results);
+    }
+    std.debug.print("Successful results: {d}/{d}\n\n", .{ httpx.successfulCount(ex_results), ex_results.len });
+
+    std.debug.print("Demo complete!\n", .{});
 }

--- a/examples/http2_client_runtime.zig
+++ b/examples/http2_client_runtime.zig
@@ -19,13 +19,12 @@ pub fn main() !void {
 
     const listen_addr = try httpx.Address.parseIp("127.0.0.1", 0);
     var listener = try httpx.TcpListener.init(listen_addr);
-    defer listener.deinit();
-
     const addr = try listener.getLocalAddress();
     const port = addr.getPort();
 
     const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&listener});
     defer server_thread.join();
+    defer listener.deinit();
 
     var client = httpx.Client.initWithConfig(allocator, .{
         .http2_enabled = true,

--- a/examples/http2_server_runtime.zig
+++ b/examples/http2_server_runtime.zig
@@ -28,7 +28,7 @@ pub fn main() !void {
 
     try server.get("/h2-server", handleH2);
 
-    const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&server});
+    const server_thread = try server.listenInBackground();
     defer server_thread.join();
     defer server.stop();
 
@@ -56,13 +56,6 @@ fn handleH2(ctx: *httpx.Context) anyerror!httpx.Response {
     return ctx.text("hello from http2 server runtime");
 }
 
-fn serverThreadMain(server: *httpx.Server) void {
-    server.listen() catch |err| {
-        if (server.running) {
-            std.debug.print("http2 server runtime error: {s}\n", .{@errorName(err)});
-        }
-    };
-}
 
 fn pickFreeTcpPort() !u16 {
     var listener = try httpx.TcpListener.init(try httpx.Address.parseIp("127.0.0.1", 0));

--- a/examples/http3_client_runtime.zig
+++ b/examples/http3_client_runtime.zig
@@ -23,8 +23,6 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     var server_socket = try httpx.UdpSocket.create();
-    defer server_socket.close();
-
     try server_socket.setReuseAddr(true);
     const listen_addr = try httpx.Address.parseIp("127.0.0.1", 0);
     try server_socket.bind(listen_addr);
@@ -34,6 +32,7 @@ pub fn main() !void {
 
     const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&server_socket});
     defer server_thread.join();
+    defer server_socket.close();
 
     var client = httpx.Client.initWithConfig(allocator, .{
         .http3_enabled = true,

--- a/examples/http3_server_runtime.zig
+++ b/examples/http3_server_runtime.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
 
     try server.get("/h3-server", handleH3);
 
-    const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&server});
+    const server_thread = try server.listenInBackground();
     defer server_thread.join();
     defer server.stop();
 
@@ -58,13 +58,6 @@ fn handleH3(ctx: *httpx.Context) anyerror!httpx.Response {
     return ctx.text("hello from http3 server runtime");
 }
 
-fn serverThreadMain(server: *httpx.Server) void {
-    server.listen() catch |err| {
-        if (server.running) {
-            std.debug.print("http3 server runtime error: {s}\n", .{@errorName(err)});
-        }
-    };
-}
 
 fn pickFreeUdpPort() !u16 {
     var socket = try httpx.UdpSocket.create();

--- a/examples/http_auth_helpers.zig
+++ b/examples/http_auth_helpers.zig
@@ -55,13 +55,6 @@ fn basicHandler(ctx: *httpx.Context) anyerror!httpx.Response {
     return ctx.json(.{ .kind = "basic", .ok = true });
 }
 
-fn serverThreadMain(server: *httpx.Server) void {
-    server.listen() catch |err| {
-        if (server.running) {
-            std.debug.print("auth demo server error: {s}\n", .{@errorName(err)});
-        }
-    };
-}
 
 pub fn main() !void {
     var gpa: std.heap.DebugAllocator(.{}) = .init;
@@ -82,7 +75,7 @@ pub fn main() !void {
     try server.get("/auth/bearer", bearerHandler);
     try server.get("/auth/basic", basicHandler);
 
-    const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&server});
+    const server_thread = try server.listenInBackground();
     defer server_thread.join();
     defer server.stop();
 

--- a/examples/proxy_example.zig
+++ b/examples/proxy_example.zig
@@ -1,0 +1,84 @@
+//! Proxy Client & Reverse Proxy Server Example
+//!
+//! Demonstrates:
+//! 1. Starting a loopback HTTP server configured with a reverse proxy middleware
+//!    forwarding requests to a mock backend.
+//! 2. Making client requests using a Client configured to route through a proxy.
+
+const std = @import("std");
+const httpx = @import("httpx");
+
+fn sleepMs(ms: i64) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.sleep(io, std.Io.Duration.fromMilliseconds(ms), .real) catch {};
+}
+
+fn mockBackendHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.text("Hello from Mock Backend!");
+}
+
+pub fn main() !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.debug.print("=== Proxy Support Example ===\n\n", .{});
+
+    const backend_port = 45233;
+    const proxy_port = 45234;
+
+    // 1. Start the mock backend server
+    var backend_server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = backend_port,
+        .keep_alive = false,
+    });
+    defer backend_server.deinit();
+    try backend_server.get("/backend-data", mockBackendHandler);
+
+    const backend_thread = try backend_server.listenInBackground();
+    defer backend_thread.join();
+    defer backend_server.stop();
+
+    sleepMs(20);
+
+    // 2. Start the proxy server. We will use the reverseProxy middleware pointing to the mock backend.
+    var proxy_server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = proxy_port,
+        .keep_alive = false,
+    });
+    defer proxy_server.deinit();
+
+    // Register reverse proxy middleware
+    try proxy_server.use(httpx.reverseProxy("http://127.0.0.1:45233"));
+
+    const proxy_thread = try proxy_server.listenInBackground();
+    defer proxy_thread.join();
+    defer proxy_server.stop();
+
+    sleepMs(20);
+
+    // 3. Setup client with proxy configuration pointing to the proxy server
+    const client_config = httpx.ClientConfig.defaults()
+        .withTimeouts(httpx.Timeouts.fast())
+        .withRetryPolicy(httpx.RetryPolicy.noRetry())
+        .withProxy(.{
+            .host = "127.0.0.1",
+            .port = proxy_port,
+        });
+
+    var client = httpx.Client.initWithConfig(allocator, client_config);
+    defer client.deinit();
+
+    // 4. Request the mock backend path through the proxy.
+    // The request to http://127.0.0.1:45233/backend-data will be routed via the proxy at 45234.
+    const target_url = "http://127.0.0.1:45233/backend-data";
+
+    std.debug.print("Sending request to {s} via proxy at 127.0.0.1:{d}...\n", .{ target_url, proxy_port });
+    var response = try client.get(target_url, .{});
+    defer response.deinit();
+
+    std.debug.print("Proxy response status: {d}\n", .{response.status.code});
+    std.debug.print("Proxy response body: {s}\n", .{response.text() orelse ""});
+}

--- a/examples/request_response_customization.zig
+++ b/examples/request_response_customization.zig
@@ -1,0 +1,153 @@
+//! Request and response customization example
+//!
+//! Demonstrates request builders, request/response helpers, response accessors,
+//! and server-side request inspection with headers, query params, JSON, and redirects.
+
+const std = @import("std");
+const httpx = @import("httpx");
+
+fn sleepMs(ms: u64) void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.sleep(io, std.Io.Duration.fromMilliseconds(@intCast(ms)), .real) catch {};
+}
+
+fn pickFreeTcpPort() !u16 {
+    var listener = try httpx.TcpListener.init(try httpx.Address.parseIp("127.0.0.1", 0));
+    defer listener.deinit();
+
+    const addr = try listener.getLocalAddress();
+    return addr.getPort();
+}
+
+fn inspectHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.json(.{
+        .method = ctx.request.method.toString(),
+        .path = ctx.request.uri.path,
+        .query = ctx.request.uri.query orelse "",
+        .accept_json = ctx.request.acceptsJson(),
+        .is_json = ctx.request.isJsonContent(),
+        .is_form = ctx.request.isFormContent(),
+        .feature_header = ctx.header("X-Feature") orelse "",
+        .authorization = ctx.authorization() orelse "",
+        .body = ctx.request.body orelse "",
+    });
+}
+
+fn renderHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.html("<h1>request/response customization</h1>");
+}
+
+fn redirectHandler(ctx: *httpx.Context) anyerror!httpx.Response {
+    return ctx.redirect("/render", 302);
+}
+
+const InspectResponse = struct {
+    method: []const u8,
+    path: []const u8,
+    query: []const u8,
+    accept_json: bool,
+    is_json: bool,
+    is_form: bool,
+    feature_header: []const u8,
+    authorization: []const u8,
+    body: []const u8,
+};
+
+pub fn main() !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.debug.print("=== Request/Response Customization Example ===\n\n", .{});
+
+    const port = try pickFreeTcpPort();
+    var server = httpx.Server.initWithConfig(allocator, .{
+        .host = "127.0.0.1",
+        .port = port,
+        .port_conflict = .fail,
+        .keep_alive = false,
+    });
+    defer server.deinit();
+
+    try server.get("/inspect", inspectHandler);
+    try server.get("/render", renderHandler);
+    try server.get("/redirect", redirectHandler);
+
+    const server_thread = try server.listenInBackground();
+    defer server_thread.join();
+    defer server.stop();
+
+    sleepMs(50);
+
+    var client = httpx.Client.initWithConfig(allocator, httpx.ClientConfig.defaults()
+        .withTimeouts(httpx.Timeouts.fast())
+        .withRetryPolicy(httpx.RetryPolicy.noRetry()));
+    defer client.deinit();
+
+    const inspect_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/inspect", .{port});
+    defer allocator.free(inspect_url);
+
+    const render_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/render", .{port});
+    defer allocator.free(render_url);
+
+    const redirect_url = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/redirect", .{port});
+    defer allocator.free(redirect_url);
+
+    var direct_request = try httpx.Request.init(allocator, .GET, inspect_url);
+    defer direct_request.deinit();
+    try direct_request.setHeader("X-Feature", "enabled");
+    try direct_request.addQueryParams(&.{.{ "mode", "direct" }});
+    try direct_request.setBearerAuth("demo-token");
+    const direct_serialized = try direct_request.toSlice(allocator);
+    defer allocator.free(direct_serialized);
+    std.debug.print("Direct request:\n{s}\n", .{direct_serialized});
+
+    var builder = httpx.RequestBuilder.init(allocator);
+    defer builder.deinit();
+    _ = builder.setMethod(.POST).setUrl(inspect_url).setVersion(.HTTP_2);
+    _ = try builder.addHeader("Accept", "application/json");
+    _ = try builder.addHeader("X-Feature", "builder");
+    _ = try builder.setJsonBody("{\"from\":\"builder\"}");
+
+    var built_request = try builder.build();
+    defer built_request.deinit();
+    const built_serialized = try built_request.toSlice(allocator);
+    defer allocator.free(built_serialized);
+    std.debug.print("Built request:\n{s}\n", .{built_serialized});
+
+    const inspect_options = httpx.RequestOptions.defaults()
+        .withHeaders(&.{
+            .{ "Accept", "application/json" },
+            .{ "X-Feature", "client" },
+        })
+        .withQueryParams(&.{.{ "mode", "client" }})
+        .withJson("{\"from\":\"client\"}")
+        .withBearerToken("demo-token");
+
+    var inspect_response = try client.post(inspect_url, inspect_options);
+    defer inspect_response.deinit();
+
+    const inspect_data = try inspect_response.json(InspectResponse);
+    std.debug.print("Inspect response: method={s} path={s} query={s} accept_json={} is_json={} header={s}\n", .{
+        inspect_data.method,
+        inspect_data.path,
+        inspect_data.query,
+        inspect_data.accept_json,
+        inspect_data.is_json,
+        inspect_data.feature_header,
+    });
+    std.debug.print("Inspect response content-type: {s}\n", .{inspect_response.contentType().?});
+    std.debug.print("Inspect response content-length: {d}\n", .{inspect_response.contentLength().?});
+
+    var render_response = try client.get(render_url, .{});
+    defer render_response.deinit();
+    std.debug.print("Render response content-type: {s}\n", .{render_response.contentType().?});
+    std.debug.print("Render response body: {s}\n", .{render_response.text().?});
+
+    var redirect_response = try client.get(redirect_url, .{});
+    defer redirect_response.deinit();
+    std.debug.print("Redirect? {} location={s}\n", .{
+        redirect_response.isRedirect(),
+        redirect_response.location().?,
+    });
+}

--- a/examples/simplified_api_aliases.zig
+++ b/examples/simplified_api_aliases.zig
@@ -44,13 +44,6 @@ fn okHandler(ctx: *httpx.Context) anyerror!httpx.Response {
     return ctx.text("ok");
 }
 
-fn serverThreadMain(server: *httpx.Server) void {
-    server.listen() catch |err| {
-        if (server.running) {
-            std.debug.print("local demo server error: {s}\n", .{@errorName(err)});
-        }
-    };
-}
 
 fn buildLocalUrls(allocator: std.mem.Allocator, port: u16) !DemoUrls {
     return .{
@@ -86,7 +79,7 @@ fn runAliasCalls(allocator: std.mem.Allocator, urls: DemoUrls) void {
     const request_timeout: u64 = 5_000;
 
     // Compile-time alias checks so this demo validates the API surface.
-    const fetch_ptr: *const fn ([]const u8) anyerror!httpx.Response = httpx.fetch;
+    const fetch_ptr: *const fn ([]const u8, httpx.RequestOptions) anyerror!httpx.Response = httpx.fetch;
     const send_ptr: *const fn (httpx.Method, []const u8, httpx.RequestOptions) anyerror!httpx.Response = httpx.send;
     const delete_ptr: *const fn ([]const u8, httpx.RequestOptions) anyerror!httpx.Response = httpx.delete;
     const opts_ptr: *const fn ([]const u8, httpx.RequestOptions) anyerror!httpx.Response = httpx.opts;
@@ -106,7 +99,7 @@ fn runAliasCalls(allocator: std.mem.Allocator, urls: DemoUrls) void {
         .json = "{\"ok\":true}",
     }));
 
-    printResult("httpx.fetch", httpx.fetch(urls.fetch));
+    printResult("httpx.fetch", httpx.fetch(urls.fetch, .{}));
     printResult("httpx.send(GET)", httpx.send(.GET, urls.get, .{}));
     printResult("httpx.delete", httpx.delete(urls.delete, .{}));
     printResult("httpx.opts", httpx.opts(urls.get, .{}));
@@ -119,7 +112,7 @@ fn runAliasCalls(allocator: std.mem.Allocator, urls: DemoUrls) void {
         .withRetryPolicy(httpx.RetryPolicy.noRetry())
         .withPoolLimits(32, 8);
 
-    var client: httpx.HttpClient = httpx.HttpClient.initWithConfig(allocator, client_config);
+    var client = httpx.Client.initWithConfig(allocator, client_config);
     defer client.deinit();
 
     printResult("client.fetch", client.fetch(urls.fetch, .{ .timeout_ms = request_timeout }));
@@ -170,8 +163,9 @@ pub fn main(init: std.process.Init) !void {
     try server.trace("/trace", okHandler);
     try server.connect("/anything", okHandler);
 
-    const server_thread = try std.Thread.spawn(.{}, serverThreadMain, .{&server});
+    const server_thread = try server.listenInBackground();
     defer server_thread.join();
+    defer server.stop();
 
     sleepMs(50);
     std.debug.print("Local demo server: http://127.0.0.1:{d}\n", .{port});
@@ -180,5 +174,4 @@ pub fn main(init: std.process.Init) !void {
     defer freeLocalUrls(allocator, urls);
 
     runAliasCalls(allocator, urls);
-    server.stop();
 }

--- a/examples/tcp_local.zig
+++ b/examples/tcp_local.zig
@@ -26,13 +26,12 @@ pub fn main() !void {
 
     const listen_addr = try httpx.Address.parseIp("127.0.0.1", 0);
     var listener = try httpx.TcpListener.init(listen_addr);
-    defer listener.deinit();
-
     const addr = try listener.getLocalAddress();
 
     var ctx = ServerCtx{ .listener = &listener };
     const thread = try std.Thread.spawn(.{}, serverThread, .{&ctx});
     defer thread.join();
+    defer listener.deinit();
 
     var client = try httpx.Socket.createForAddress(addr);
     defer client.close();

--- a/examples/udp_local.zig
+++ b/examples/udp_local.zig
@@ -30,5 +30,5 @@ pub fn main() !void {
 
     std.debug.print("Sent: {s}\n", .{msg});
     std.debug.print("Recv: {s}\n", .{buf[0..got.n]});
-    std.debug.print("From: {f}\n", .{got.addr});
+    std.debug.print("From: {}\n", .{got.addr});
 }

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -69,6 +69,7 @@ pub const ClientConfig = struct {
     keep_alive: bool = true,
     pool_max_connections: u32 = 20,
     pool_max_per_host: u32 = 5,
+    proxy: ?types.Proxy = null,
 
     /// Returns default client configuration.
     pub fn defaults() ClientConfig {
@@ -78,6 +79,13 @@ pub const ClientConfig = struct {
     /// Returns default configuration with a base URL.
     pub fn forBaseUrl(base_url: []const u8) ClientConfig {
         return .{ .base_url = base_url };
+    }
+
+    /// Returns a copy with a proxy configured.
+    pub fn withProxy(self: ClientConfig, proxy: ?types.Proxy) ClientConfig {
+        var out = self;
+        out.proxy = proxy;
+        return out;
     }
 
     /// Returns a copy with a new base URL.
@@ -519,6 +527,65 @@ pub const Client = struct {
             mem.eql(u8, name, "TooManyRedirects"));
     }
 
+    fn formatProxyRequest(self: *Self, req: *const Request, proxy: types.Proxy) ![]u8 {
+        var buffer = std.ArrayList(u8).empty;
+        const writer = list_writer.init(self.allocator, &buffer);
+
+        const method_str = req.method.toString();
+        // Construct absolute URI
+        try writer.print("{s} http://{s}:{d}{s}", .{ method_str, req.uri.host orelse "", req.uri.effectivePort(), req.uri.path });
+        if (req.uri.query) |q| {
+            try writer.print("?{s}", .{q});
+        }
+        try writer.print(" {s}\r\n", .{req.version.toString()});
+
+        for (req.headers.entries.items) |h| {
+            try writer.print("{s}: {s}\r\n", .{ h.name, h.value });
+        }
+
+        if (proxy.username) |user| {
+            const pass = proxy.password orelse "";
+            const auth_val = try @import("../util/encoding.zig").Base64.formatBasicAuth(self.allocator, user, pass);
+            defer self.allocator.free(auth_val);
+            try writer.print("Proxy-Authorization: {s}\r\n", .{auth_val});
+        }
+
+        try writer.writeAll("\r\n");
+
+        if (req.body) |body| {
+            try writer.writeAll(body);
+        }
+
+        return buffer.toOwnedSlice(self.allocator);
+    }
+
+    fn establishProxyTlsTunnel(self: *Self, socket: *Socket, target_host: []const u8, target_port: u16, proxy: types.Proxy) !void {
+        var buffer = std.ArrayList(u8).empty;
+        const writer = list_writer.init(self.allocator, &buffer);
+
+        try writer.print("CONNECT {s}:{d} HTTP/1.1\r\nHost: {s}:{d}\r\n", .{ target_host, target_port, target_host, target_port });
+
+        if (proxy.username) |user| {
+            const pass = proxy.password orelse "";
+            const auth_val = try @import("../util/encoding.zig").Base64.formatBasicAuth(self.allocator, user, pass);
+            defer self.allocator.free(auth_val);
+            try writer.print("Proxy-Authorization: {s}\r\n", .{auth_val});
+        }
+        try writer.writeAll("\r\n");
+
+        const connect_req = try buffer.toOwnedSlice(self.allocator);
+        defer self.allocator.free(connect_req);
+
+        try socket.sendAll(connect_req);
+
+        var response = try self.readResponseFromTcp(socket);
+        defer response.deinit();
+
+        if (response.status.code < 200 or response.status.code >= 300) {
+            return error.ProxyConnectionFailed;
+        }
+    }
+
     fn executeRequestOnce(self: *Self, req: *Request, timeout_override_ms: ?u64) !Response {
         const host = req.uri.host orelse return error.InvalidUri;
         const port = req.uri.effectivePort();
@@ -529,6 +596,7 @@ pub const Client = struct {
         const wants_http3 = self.config.http3_enabled or req.version == .HTTP_3;
 
         if (wants_http3) {
+            if (self.config.proxy != null) return error.ProxyNotSupported;
             return self.executeRequestHttp3(req, host, port, timeout_ms, write_timeout_ms);
         }
 
@@ -536,12 +604,22 @@ pub const Client = struct {
             return self.executeRequestHttp2(req, host, port, timeout_ms, write_timeout_ms);
         }
 
-        const request_data = try http.formatRequest(req, self.allocator);
+        var request_data: []u8 = undefined;
+        if (self.config.proxy) |proxy| {
+            if (!req.uri.isTls()) {
+                request_data = try self.formatProxyRequest(req, proxy);
+            } else {
+                request_data = try http.formatRequest(req, self.allocator);
+            }
+        } else {
+            request_data = try http.formatRequest(req, self.allocator);
+        }
         defer self.allocator.free(request_data);
 
         if (req.uri.isTls()) {
-            // TLS pooling requires keeping a live TLS session; not implemented yet.
-            const addr = try address_mod.resolve(host, port);
+            const connect_host = if (self.config.proxy) |p| p.host else host;
+            const connect_port = if (self.config.proxy) |p| p.port else port;
+            const addr = try address_mod.resolve(connect_host, connect_port);
 
             var socket = try Socket.createForAddress(addr);
             defer socket.close();
@@ -555,11 +633,15 @@ pub const Client = struct {
 
             try socket.connect(addr);
 
+            if (self.config.proxy) |proxy| {
+                try self.establishProxyTlsTunnel(&socket, host, port, proxy);
+            }
+
             return self.executeTlsHttp(&socket, host, request_data);
         }
 
         if (self.config.keep_alive) {
-            var conn = try self.pool.getConnection(host, port);
+            var conn = try self.pool.getConnection(host, port, self.config.proxy);
             errdefer conn.close();
             defer self.pool.releaseConnection(conn);
 
@@ -579,7 +661,9 @@ pub const Client = struct {
             return res;
         }
 
-        const addr = try address_mod.resolve(host, port);
+        const connect_host = if (self.config.proxy) |p| p.host else host;
+        const connect_port = if (self.config.proxy) |p| p.port else port;
+        const addr = try address_mod.resolve(connect_host, connect_port);
 
         var socket = try Socket.createForAddress(addr);
         defer socket.close();
@@ -605,7 +689,9 @@ pub const Client = struct {
         timeout_ms: u64,
         write_timeout_ms: u64,
     ) !Response {
-        const addr = try address_mod.resolve(host, port);
+        const connect_host = if (self.config.proxy) |p| p.host else host;
+        const connect_port = if (self.config.proxy) |p| p.port else port;
+        const addr = try address_mod.resolve(connect_host, connect_port);
 
         var socket = try Socket.createForAddress(addr);
         defer socket.close();
@@ -618,6 +704,10 @@ pub const Client = struct {
         }
 
         try socket.connect(addr);
+
+        if (self.config.proxy) |proxy| {
+            try self.establishProxyTlsTunnel(&socket, host, port, proxy);
+        }
 
         if (req.uri.isTls()) {
             const tls_cfg = if (self.config.verify_ssl) TlsConfig.init(self.allocator) else TlsConfig.insecure(self.allocator);
@@ -1411,13 +1501,8 @@ pub const Client = struct {
     }
 
     /// OPTIONS request convenience method.
-    pub fn httpOptions(self: *Self, url: []const u8, reqOpts: RequestOptions) !Response {
-        return self.request(.OPTIONS, url, reqOpts);
-    }
-
-    /// Alias for httpOptions() with conventional method naming.
     pub fn options(self: *Self, url: []const u8, reqOpts: RequestOptions) !Response {
-        return self.httpOptions(url, reqOpts);
+        return self.request(.OPTIONS, url, reqOpts);
     }
 
     /// Alias for options() with short method naming.
@@ -1730,6 +1815,19 @@ test "Client initForBaseUrl helper" {
     try std.testing.expectEqualStrings("https://api.example.com", client.config.base_url.?);
 }
 
+test "Client initialization defaults" {
+    const allocator = std.testing.allocator;
+    var client = Client.init(allocator);
+    defer client.deinit();
+
+    try std.testing.expect(client.config.base_url == null);
+    try std.testing.expect(client.config.keep_alive);
+    try std.testing.expect(client.config.follow_redirects);
+    try std.testing.expect(client.config.verify_ssl);
+    try std.testing.expectEqual(@as(u32, 20), client.config.pool_max_connections);
+    try std.testing.expectEqual(@as(u32, 5), client.config.pool_max_per_host);
+}
+
 test "ClientConfig builder helpers" {
     const default_headers = [_][2][]const u8{
         .{ "Accept", "application/json" },
@@ -1749,7 +1847,8 @@ test "ClientConfig builder helpers" {
         .withSslVerification(false)
         .withKeepAlive(false)
         .withMaxResponseSize(1024)
-        .withPoolLimits(64, 16);
+        .withPoolLimits(64, 16)
+        .withProxy(.{ .host = "127.0.0.1", .port = 8080 });
 
     try std.testing.expectEqualStrings("https://api.example.com", cfg.base_url.?);
     try std.testing.expectEqual(@as(u64, 5_000), cfg.timeouts.connect_ms);
@@ -1768,6 +1867,9 @@ test "ClientConfig builder helpers" {
     try std.testing.expectEqual(@as(usize, 1024), cfg.max_response_size);
     try std.testing.expectEqual(@as(u32, 64), cfg.pool_max_connections);
     try std.testing.expectEqual(@as(u32, 16), cfg.pool_max_per_host);
+    try std.testing.expect(cfg.proxy != null);
+    try std.testing.expectEqualStrings("127.0.0.1", cfg.proxy.?.host);
+    try std.testing.expectEqual(@as(u16, 8080), cfg.proxy.?.port);
 }
 
 test "RequestOptions builder helpers" {
@@ -2225,4 +2327,26 @@ fn countWrittenHttp2Frames(data: []const u8, frame_type: http.Http2FrameType) us
     }
 
     return count;
+}
+
+test "Client proxy request formatting" {
+    const allocator = std.testing.allocator;
+    var client = Client.initWithConfig(allocator, .{});
+    defer client.deinit();
+
+    var req = try Request.init(allocator, .GET, "http://example.com/api/v1/users?active=true");
+    defer req.deinit();
+    try req.headers.set("Accept", "application/json");
+
+    const formatted = try client.formatProxyRequest(&req, .{
+        .host = "127.0.0.1",
+        .port = 8080,
+        .username = "user",
+        .password = "pass",
+    });
+    defer allocator.free(formatted);
+
+    try std.testing.expect(std.mem.indexOf(u8, formatted, "GET http://example.com:80/api/v1/users?active=true HTTP/1.1\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, formatted, "Accept: application/json\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, formatted, "Proxy-Authorization: Basic dXNlcjpwYXNz\r\n") != null);
 }

--- a/src/client/pool.zig
+++ b/src/client/pool.zig
@@ -13,6 +13,8 @@ const builtin = @import("builtin");
 
 const Socket = @import("../net/socket.zig").Socket;
 const address_mod = @import("../net/address.zig");
+const types = @import("../core/types.zig");
+const Proxy = types.Proxy;
 
 fn nowMillis() i64 {
     const io = if (builtin.is_test)
@@ -127,7 +129,7 @@ pub const ConnectionPool = struct {
     }
 
     /// Gets or creates a connection to the specified host.
-    pub fn getConnection(self: *Self, host: []const u8, port: u16) !*Connection {
+    pub fn getConnection(self: *Self, host: []const u8, port: u16, proxy: ?Proxy) !*Connection {
         for (self.connections.items) |*conn| {
             if (std.mem.eql(u8, conn.host, host) and conn.port == port) {
                 if (conn.isHealthy(self.config.idle_timeout_ms) and conn.requests_made < self.config.max_requests_per_connection) {
@@ -145,15 +147,17 @@ pub const ConnectionPool = struct {
         }
         if (host_count >= self.config.max_per_host) return PoolError.PoolExhaustedForHost;
 
-        return self.createConnection(host, port);
+        return self.createConnection(host, port, proxy);
     }
 
     /// Creates a new connection.
-    fn createConnection(self: *Self, host: []const u8, port: u16) !*Connection {
+    fn createConnection(self: *Self, host: []const u8, port: u16, proxy: ?Proxy) !*Connection {
         const host_owned = try self.allocator.dupe(u8, host);
         try self.hosts_owned.append(self.allocator, host_owned);
 
-        const addr = try address_mod.resolve(host, port);
+        const connect_host = if (proxy) |p| p.host else host;
+        const connect_port = if (proxy) |p| p.port else port;
+        const addr = try address_mod.resolve(connect_host, connect_port);
 
         var socket = try Socket.createForAddress(addr);
         errdefer socket.close();

--- a/src/concurrency/executor.zig
+++ b/src/concurrency/executor.zig
@@ -94,7 +94,7 @@ pub const Executor = struct {
         }
 
         try self.tasks.append(self.allocator, task);
-        self.cond.signal();
+        self.cond.signal(io);
     }
 
     /// Submits a function for execution.
@@ -127,7 +127,7 @@ pub const Executor = struct {
         const io = defaultIo();
         self.mutex.lock(io) catch unreachable;
         self.running = false;
-        self.cond.broadcast();
+        self.cond.broadcast(io);
         self.mutex.unlock(io);
 
         for (self.threads) |thread| thread.join();
@@ -230,6 +230,16 @@ test "Executor initialization" {
     defer exec.deinit();
 
     try std.testing.expect(exec.config.num_threads > 0);
+}
+
+test "Executor initWithConfig applies explicit overrides" {
+    const allocator = std.testing.allocator;
+    var exec = Executor.initWithConfig(allocator, .{ .num_threads = 2, .task_queue_size = 8, .idle_timeout_ms = 1234 });
+    defer exec.deinit();
+
+    try std.testing.expectEqual(@as(u32, 2), exec.config.num_threads);
+    try std.testing.expectEqual(@as(usize, 8), exec.config.task_queue_size);
+    try std.testing.expectEqual(@as(u64, 1234), exec.config.idle_timeout_ms);
 }
 
 test "Executor task submission" {

--- a/src/concurrency/pool.zig
+++ b/src/concurrency/pool.zig
@@ -122,44 +122,132 @@ pub const BatchBuilder = struct {
     }
 };
 
+pub const ConcurrencyMode = enum {
+    single_thread,
+    multi_thread,
+    explicit_workers,
+};
+
+pub const ConcurrencyConfig = struct {
+    mode: ConcurrencyMode = .multi_thread,
+    workers: ?u32 = null,
+    executor: ?*@import("executor.zig").Executor = null,
+};
+
 /// Executes all requests and waits for all to complete.
-pub fn all(allocator: Allocator, client: *Client, specs: []const RequestSpec) ![]RequestResult {
+pub fn all(allocator: Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) ![]RequestResult {
     var results = try allocator.alloc(RequestResult, specs.len);
     errdefer allocator.free(results);
 
     if (specs.len == 0) return results;
 
-    const WorkerCtx = struct {
-        client: *Client,
-        spec: RequestSpec,
-        out: *RequestResult,
+    switch (config.mode) {
+        .single_thread => {
+            for (specs, 0..) |spec, i| {
+                results[i] = executeSpec(client, spec);
+            }
+        },
+        .multi_thread => {
+            const workers_count = @max(1, @min(config.workers orelse specs.len, specs.len));
+            var next_spec_idx = std.atomic.Value(usize).init(0);
 
-        fn run(self: *@This()) void {
-            self.out.* = executeSpec(self.client, self.spec);
-        }
-    };
+            const Worker = struct {
+                client: *Client,
+                specs: []const RequestSpec,
+                results: []RequestResult,
+                next_idx: *std.atomic.Value(usize),
 
-    var threads = try allocator.alloc(Thread, specs.len);
-    defer allocator.free(threads);
+                fn run(self: *@This()) void {
+                    while (true) {
+                        const idx = self.next_idx.fetchAdd(1, .acq_rel);
+                        if (idx >= self.specs.len) break;
+                        self.results[idx] = executeSpec(self.client, self.specs[idx]);
+                    }
+                }
+            };
 
-    var ctxs = try allocator.alloc(WorkerCtx, specs.len);
-    defer allocator.free(ctxs);
+            var threads = try allocator.alloc(Thread, workers_count);
+            defer allocator.free(threads);
 
-    var spawned: usize = 0;
-    errdefer {
-        var i: usize = 0;
-        while (i < spawned) : (i += 1) {
-            threads[i].join();
-        }
+            var workers = try allocator.alloc(Worker, workers_count);
+            defer allocator.free(workers);
+
+            var spawned: usize = 0;
+            errdefer {
+                var i: usize = 0;
+                while (i < spawned) : (i += 1) {
+                    threads[i].join();
+                }
+            }
+
+            for (0..workers_count) |i| {
+                workers[i] = .{
+                    .client = client,
+                    .specs = specs,
+                    .results = results,
+                    .next_idx = &next_spec_idx,
+                };
+                threads[i] = try Thread.spawn(.{}, Worker.run, .{&workers[i]});
+                spawned += 1;
+            }
+
+            for (threads[0..spawned]) |t| {
+                t.join();
+            }
+        },
+        .explicit_workers => {
+            const exec = config.executor orelse return error.MissingExecutor;
+            var remaining = std.atomic.Value(usize).init(specs.len);
+            var mutex: std.Io.Mutex = .init;
+            var cond: std.Io.Condition = .init;
+
+            const TaskCtx = struct {
+                client: *Client,
+                spec: RequestSpec,
+                out: *RequestResult,
+                remaining: *std.atomic.Value(usize),
+                mutex: *std.Io.Mutex,
+                cond: *std.Io.Condition,
+
+                fn run(ctx_ptr: ?*anyopaque) void {
+                    const self: *@This() = @ptrCast(@alignCast(ctx_ptr.?));
+                    self.out.* = executeSpec(self.client, self.spec);
+                    const prev = self.remaining.fetchSub(1, .acq_rel);
+                    if (prev == 1) {
+                        const io = defaultIo();
+                        self.mutex.lock(io) catch unreachable;
+                        self.cond.signal(io);
+                        self.mutex.unlock(io);
+                    }
+                }
+            };
+
+            var ctxs = try allocator.alloc(TaskCtx, specs.len);
+            defer allocator.free(ctxs);
+
+            for (specs, 0..) |spec, i| {
+                ctxs[i] = .{
+                    .client = client,
+                    .spec = spec,
+                    .out = &results[i],
+                    .remaining = &remaining,
+                    .mutex = &mutex,
+                    .cond = &cond,
+                };
+                try exec.submit(.{
+                    .func = TaskCtx.run,
+                    .context = &ctxs[i],
+                });
+            }
+
+            const io = defaultIo();
+            mutex.lock(io) catch unreachable;
+            while (remaining.load(.acquire) > 0) {
+                cond.wait(io, &mutex) catch unreachable;
+            }
+            mutex.unlock(io);
+        },
     }
-
-    for (specs, 0..) |spec, i| {
-        ctxs[i] = .{ .client = client, .spec = spec, .out = &results[i] };
-        threads[i] = try Thread.spawn(.{}, WorkerCtx.run, .{&ctxs[i]});
-        spawned += 1;
-    }
-
-    for (threads[0..spawned]) |t| t.join();
 
     return results;
 }
@@ -168,8 +256,8 @@ pub fn all(allocator: Allocator, client: *Client, specs: []const RequestSpec) ![
 ///
 /// Unlike `all`, this never fails due to a request error; request failures are
 /// represented as `RequestResult.err` values.
-pub fn allSettled(allocator: Allocator, client: *Client, specs: []const RequestSpec) ![]RequestResult {
-    return all(allocator, client, specs);
+pub fn allSettled(allocator: Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) ![]RequestResult {
+    return all(allocator, client, specs, config);
 }
 
 /// Counts successful request results.
@@ -187,177 +275,364 @@ pub fn errorCount(results: []const RequestResult) usize {
 }
 
 /// Executes all requests and returns the first successful response.
-pub fn any(allocator: Allocator, client: *Client, specs: []const RequestSpec) !?Response {
-    _ = allocator;
-
+pub fn any(allocator: Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !?Response {
     if (specs.len == 0) return null;
 
-    // NOTE: This function assumes `client` (and its allocator) are safe to use
-    // concurrently. If you pass a non-thread-safe allocator, behavior is undefined.
-    const WorkerCtx = struct {
-        client: *Client,
-        spec: RequestSpec,
-        winner: *std.atomic.Value(bool),
-        result: *?Response,
-        mutex: *std.Io.Mutex,
-        cond: *std.Io.Condition,
-        remaining: *std.atomic.Value(usize),
-
-        fn run(self: *@This()) void {
-            var rr = executeSpec(self.client, self.spec);
-            defer rr.deinit();
-
-            if (rr == .success and rr.success.status.isSuccess()) {
-                if (!self.winner.swap(true, .acq_rel)) {
-                    const io = defaultIo();
-                    self.mutex.lock(io) catch unreachable;
-                    self.result.* = rr.success;
-                    // transfer ownership to caller
-                    rr = .{ .err = error.UnusedResult };
-                    self.cond.signal(io);
-                    self.mutex.unlock(io);
+    switch (config.mode) {
+        .single_thread => {
+            for (specs) |spec| {
+                var r = executeSpec(client, spec);
+                if (r == .success and r.success.status.isSuccess()) {
+                    const res = r.success;
+                    r = .{ .err = error.UnusedResult };
+                    return res;
                 }
+                r.deinit();
+            }
+            return null;
+        },
+        .multi_thread => {
+            const workers_count = @max(1, @min(config.workers orelse specs.len, specs.len));
+            var next_spec_idx = std.atomic.Value(usize).init(0);
+            var winner = std.atomic.Value(bool).init(false);
+            var remaining = std.atomic.Value(usize).init(specs.len);
+            var mutex: std.Io.Mutex = .init;
+            var cond: std.Io.Condition = .init;
+            var result: ?Response = null;
+
+            const Worker = struct {
+                client: *Client,
+                specs: []const RequestSpec,
+                next_idx: *std.atomic.Value(usize),
+                winner: *std.atomic.Value(bool),
+                result: *?Response,
+                mutex: *std.Io.Mutex,
+                cond: *std.Io.Condition,
+                remaining: *std.atomic.Value(usize),
+
+                fn run(self: *@This()) void {
+                    while (true) {
+                        if (self.winner.load(.acquire)) break;
+                        const idx = self.next_idx.fetchAdd(1, .acq_rel);
+                        if (idx >= self.specs.len) break;
+
+                        var rr = executeSpec(self.client, self.specs[idx]);
+                        defer rr.deinit();
+
+                        if (rr == .success and rr.success.status.isSuccess()) {
+                            if (!self.winner.swap(true, .acq_rel)) {
+                                const io = defaultIo();
+                                self.mutex.lock(io) catch unreachable;
+                                self.result.* = rr.success;
+                                rr = .{ .err = error.UnusedResult }; // transfer ownership
+                                self.cond.signal(io);
+                                self.mutex.unlock(io);
+                                break;
+                            }
+                        }
+
+                        const prev = self.remaining.fetchSub(1, .acq_rel);
+                        if (prev == 1) {
+                            const io = defaultIo();
+                            self.mutex.lock(io) catch unreachable;
+                            self.cond.signal(io);
+                            self.mutex.unlock(io);
+                        }
+                    }
+                }
+            };
+
+            var threads = try allocator.alloc(Thread, workers_count);
+            defer allocator.free(threads);
+
+            var workers = try allocator.alloc(Worker, workers_count);
+            defer allocator.free(workers);
+
+            var spawned: usize = 0;
+            errdefer {
+                var i: usize = 0;
+                while (i < spawned) : (i += 1) threads[i].join();
+                if (result) |*r| r.deinit();
             }
 
-            const prev = self.remaining.fetchSub(1, .acq_rel);
-            if (prev == 1) {
-                const io = defaultIo();
-                self.mutex.lock(io) catch unreachable;
-                self.cond.signal(io);
-                self.mutex.unlock(io);
+            for (0..workers_count) |i| {
+                workers[i] = .{
+                    .client = client,
+                    .specs = specs,
+                    .next_idx = &next_spec_idx,
+                    .winner = &winner,
+                    .result = &result,
+                    .mutex = &mutex,
+                    .cond = &cond,
+                    .remaining = &remaining,
+                };
+                threads[i] = try Thread.spawn(.{}, Worker.run, .{&workers[i]});
+                spawned += 1;
             }
-        }
-    };
 
-    var winner = std.atomic.Value(bool).init(false);
-    var remaining = std.atomic.Value(usize).init(specs.len);
-    var mutex: std.Io.Mutex = .init;
-    var cond: std.Io.Condition = .init;
-    var result: ?Response = null;
+            const any_io = defaultIo();
+            mutex.lock(any_io) catch unreachable;
+            while (!winner.load(.acquire) and remaining.load(.acquire) > (specs.len - spawned)) {
+                cond.wait(any_io, &mutex) catch unreachable;
+            }
+            mutex.unlock(any_io);
 
-    var threads = try std.heap.page_allocator.alloc(Thread, specs.len);
-    defer std.heap.page_allocator.free(threads);
+            for (threads[0..spawned]) |t| t.join();
 
-    var ctxs = try std.heap.page_allocator.alloc(WorkerCtx, specs.len);
-    defer std.heap.page_allocator.free(ctxs);
+            return result;
+        },
+        .explicit_workers => {
+            const exec = config.executor orelse return error.MissingExecutor;
+            var winner = std.atomic.Value(bool).init(false);
+            var remaining = std.atomic.Value(usize).init(specs.len);
+            var mutex: std.Io.Mutex = .init;
+            var cond: std.Io.Condition = .init;
+            var result: ?Response = null;
 
-    var spawned: usize = 0;
-    errdefer {
-        var i: usize = 0;
-        while (i < spawned) : (i += 1) threads[i].join();
-        if (result) |*r| r.deinit();
+            const TaskCtx = struct {
+                client: *Client,
+                spec: RequestSpec,
+                winner: *std.atomic.Value(bool),
+                result: *?Response,
+                mutex: *std.Io.Mutex,
+                cond: *std.Io.Condition,
+                remaining: *std.atomic.Value(usize),
+
+                fn run(ctx_ptr: ?*anyopaque) void {
+                    const self: *@This() = @ptrCast(@alignCast(ctx_ptr.?));
+                    if (self.winner.load(.acquire)) {
+                        _ = self.remaining.fetchSub(1, .acq_rel);
+                        return;
+                    }
+
+                    var rr = executeSpec(self.client, self.spec);
+                    defer rr.deinit();
+
+                    if (rr == .success and rr.success.status.isSuccess()) {
+                        if (!self.winner.swap(true, .acq_rel)) {
+                            const io = defaultIo();
+                            self.mutex.lock(io) catch unreachable;
+                            self.result.* = rr.success;
+                            rr = .{ .err = error.UnusedResult };
+                            self.cond.signal(io);
+                            self.mutex.unlock(io);
+                        }
+                    }
+
+                    const prev = self.remaining.fetchSub(1, .acq_rel);
+                    if (prev == 1) {
+                        const io = defaultIo();
+                        self.mutex.lock(io) catch unreachable;
+                        self.cond.signal(io);
+                        self.mutex.unlock(io);
+                    }
+                }
+            };
+
+            var ctxs = try allocator.alloc(TaskCtx, specs.len);
+            defer allocator.free(ctxs);
+
+            for (specs, 0..) |spec, i| {
+                ctxs[i] = .{
+                    .client = client,
+                    .spec = spec,
+                    .winner = &winner,
+                    .result = &result,
+                    .mutex = &mutex,
+                    .cond = &cond,
+                    .remaining = &remaining,
+                };
+                try exec.submit(.{
+                    .func = TaskCtx.run,
+                    .context = &ctxs[i],
+                });
+            }
+
+            const io = defaultIo();
+            mutex.lock(io) catch unreachable;
+            while (!winner.load(.acquire) and remaining.load(.acquire) > 0) {
+                cond.wait(io, &mutex) catch unreachable;
+            }
+            mutex.unlock(io);
+
+            return result;
+        },
     }
-
-    for (specs, 0..) |spec, i| {
-        ctxs[i] = .{
-            .client = client,
-            .spec = spec,
-            .winner = &winner,
-            .result = &result,
-            .mutex = &mutex,
-            .cond = &cond,
-            .remaining = &remaining,
-        };
-        threads[i] = try Thread.spawn(.{}, WorkerCtx.run, .{&ctxs[i]});
-        spawned += 1;
-    }
-
-    // Wait until a success is found or all workers complete.
-    const any_io = defaultIo();
-    mutex.lock(any_io) catch unreachable;
-    while (!winner.load(.acquire) and remaining.load(.acquire) != 0) {
-        cond.wait(any_io, &mutex) catch unreachable;
-    }
-    mutex.unlock(any_io);
-
-    for (threads[0..spawned]) |t| t.join();
-
-    return result;
 }
 
 /// Executes all requests and returns the first to complete.
-pub fn race(allocator: Allocator, client: *Client, specs: []const RequestSpec) !RequestResult {
-    _ = allocator;
-
+pub fn race(allocator: Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !RequestResult {
     if (specs.len == 0) return .{ .err = error.NoRequests };
 
-    const WorkerCtx = struct {
-        client: *Client,
-        spec: RequestSpec,
-        winner: *std.atomic.Value(bool),
-        result: *RequestResult,
-        mutex: *std.Io.Mutex,
-        cond: *std.Io.Condition,
-        remaining: *std.atomic.Value(usize),
+    switch (config.mode) {
+        .single_thread => {
+            return executeSpec(client, specs[0]);
+        },
+        .multi_thread => {
+            const workers_count = @max(1, @min(config.workers orelse specs.len, specs.len));
+            var next_spec_idx = std.atomic.Value(usize).init(0);
+            var winner = std.atomic.Value(bool).init(false);
+            var remaining = std.atomic.Value(usize).init(specs.len);
+            var mutex: std.Io.Mutex = .init;
+            var cond: std.Io.Condition = .init;
+            var result: RequestResult = .{ .err = error.NoRequests };
 
-        fn run(self: *@This()) void {
-            var rr = executeSpec(self.client, self.spec);
+            const Worker = struct {
+                client: *Client,
+                specs: []const RequestSpec,
+                next_idx: *std.atomic.Value(usize),
+                winner: *std.atomic.Value(bool),
+                result: *RequestResult,
+                mutex: *std.Io.Mutex,
+                cond: *std.Io.Condition,
+                remaining: *std.atomic.Value(usize),
 
-            if (!self.winner.swap(true, .acq_rel)) {
-                const io = defaultIo();
-                self.mutex.lock(io) catch unreachable;
-                self.result.* = rr;
-                self.cond.signal(io);
-                self.mutex.unlock(io);
-                // ownership transferred to caller
-                rr = .{ .err = error.UnusedResult };
+                fn run(self: *@This()) void {
+                    while (true) {
+                        if (self.winner.load(.acquire)) break;
+                        const idx = self.next_idx.fetchAdd(1, .acq_rel);
+                        if (idx >= self.specs.len) break;
+
+                        var rr = executeSpec(self.client, self.specs[idx]);
+
+                        if (!self.winner.swap(true, .acq_rel)) {
+                            const io = defaultIo();
+                            self.mutex.lock(io) catch unreachable;
+                            self.result.* = rr;
+                            rr = .{ .err = error.UnusedResult };
+                            self.cond.signal(io);
+                            self.mutex.unlock(io);
+                            break;
+                        }
+
+                        rr.deinit();
+
+                        const prev = self.remaining.fetchSub(1, .acq_rel);
+                        if (prev == 1) {
+                            const io = defaultIo();
+                            self.mutex.lock(io) catch unreachable;
+                            self.cond.signal(io);
+                            self.mutex.unlock(io);
+                        }
+                    }
+                }
+            };
+
+            var threads = try allocator.alloc(Thread, workers_count);
+            defer allocator.free(threads);
+
+            var workers = try allocator.alloc(Worker, workers_count);
+            defer allocator.free(workers);
+
+            var spawned: usize = 0;
+            errdefer {
+                var i: usize = 0;
+                while (i < spawned) : (i += 1) threads[i].join();
+                result.deinit();
             }
 
-            rr.deinit();
-
-            const prev = self.remaining.fetchSub(1, .acq_rel);
-            if (prev == 1) {
-                const io = defaultIo();
-                self.mutex.lock(io) catch unreachable;
-                self.cond.signal(io);
-                self.mutex.unlock(io);
+            for (0..workers_count) |i| {
+                workers[i] = .{
+                    .client = client,
+                    .specs = specs,
+                    .next_idx = &next_spec_idx,
+                    .winner = &winner,
+                    .result = &result,
+                    .mutex = &mutex,
+                    .cond = &cond,
+                    .remaining = &remaining,
+                };
+                threads[i] = try Thread.spawn(.{}, Worker.run, .{&workers[i]});
+                spawned += 1;
             }
-        }
-    };
 
-    var winner = std.atomic.Value(bool).init(false);
-    var remaining = std.atomic.Value(usize).init(specs.len);
-    var mutex: std.Io.Mutex = .init;
-    var cond: std.Io.Condition = .init;
-    var result: RequestResult = .{ .err = error.NoRequests };
+            const race_io = defaultIo();
+            mutex.lock(race_io) catch unreachable;
+            while (!winner.load(.acquire) and remaining.load(.acquire) > (specs.len - spawned)) {
+                cond.wait(race_io, &mutex) catch unreachable;
+            }
+            mutex.unlock(race_io);
 
-    var threads = try std.heap.page_allocator.alloc(Thread, specs.len);
-    defer std.heap.page_allocator.free(threads);
+            for (threads[0..spawned]) |t| t.join();
 
-    var ctxs = try std.heap.page_allocator.alloc(WorkerCtx, specs.len);
-    defer std.heap.page_allocator.free(ctxs);
+            return result;
+        },
+        .explicit_workers => {
+            const exec = config.executor orelse return error.MissingExecutor;
+            var winner = std.atomic.Value(bool).init(false);
+            var remaining = std.atomic.Value(usize).init(specs.len);
+            var mutex: std.Io.Mutex = .init;
+            var cond: std.Io.Condition = .init;
+            var result: RequestResult = .{ .err = error.NoRequests };
 
-    var spawned: usize = 0;
-    errdefer {
-        var i: usize = 0;
-        while (i < spawned) : (i += 1) threads[i].join();
-        result.deinit();
+            const TaskCtx = struct {
+                client: *Client,
+                spec: RequestSpec,
+                winner: *std.atomic.Value(bool),
+                result: *RequestResult,
+                mutex: *std.Io.Mutex,
+                cond: *std.Io.Condition,
+                remaining: *std.atomic.Value(usize),
+
+                fn run(ctx_ptr: ?*anyopaque) void {
+                    const self: *@This() = @ptrCast(@alignCast(ctx_ptr.?));
+                    if (self.winner.load(.acquire)) {
+                        _ = self.remaining.fetchSub(1, .acq_rel);
+                        return;
+                    }
+
+                    var rr = executeSpec(self.client, self.spec);
+
+                    if (!self.winner.swap(true, .acq_rel)) {
+                        const io = defaultIo();
+                        self.mutex.lock(io) catch unreachable;
+                        self.result.* = rr;
+                        rr = .{ .err = error.UnusedResult };
+                        self.cond.signal(io);
+                        self.mutex.unlock(io);
+                    }
+
+                    rr.deinit();
+
+                    const prev = self.remaining.fetchSub(1, .acq_rel);
+                    if (prev == 1) {
+                        const io = defaultIo();
+                        self.mutex.lock(io) catch unreachable;
+                        self.cond.signal(io);
+                        self.mutex.unlock(io);
+                    }
+                }
+            };
+
+            var ctxs = try allocator.alloc(TaskCtx, specs.len);
+            defer allocator.free(ctxs);
+
+            for (specs, 0..) |spec, i| {
+                ctxs[i] = .{
+                    .client = client,
+                    .spec = spec,
+                    .winner = &winner,
+                    .result = &result,
+                    .mutex = &mutex,
+                    .cond = &cond,
+                    .remaining = &remaining,
+                };
+                try exec.submit(.{
+                    .func = TaskCtx.run,
+                    .context = &ctxs[i],
+                });
+            }
+
+            const io = defaultIo();
+            mutex.lock(io) catch unreachable;
+            while (!winner.load(.acquire) and remaining.load(.acquire) > 0) {
+                cond.wait(io, &mutex) catch unreachable;
+            }
+            mutex.unlock(io);
+
+            return result;
+        },
     }
-
-    for (specs, 0..) |spec, i| {
-        ctxs[i] = .{
-            .client = client,
-            .spec = spec,
-            .winner = &winner,
-            .result = &result,
-            .mutex = &mutex,
-            .cond = &cond,
-            .remaining = &remaining,
-        };
-        threads[i] = try Thread.spawn(.{}, WorkerCtx.run, .{&ctxs[i]});
-        spawned += 1;
-    }
-
-    const race_io = defaultIo();
-    mutex.lock(race_io) catch unreachable;
-    while (!winner.load(.acquire) and remaining.load(.acquire) != 0) {
-        cond.wait(race_io, &mutex) catch unreachable;
-    }
-    mutex.unlock(race_io);
-
-    for (threads[0..spawned]) |t| t.join();
-
-    return result;
 }
 
 fn executeSpec(client: *Client, spec: RequestSpec) RequestResult {
@@ -430,7 +705,7 @@ test "allSettled empty" {
     var client = Client.init(allocator);
     defer client.deinit();
 
-    const results = try allSettled(allocator, &client, &.{});
+    const results = try allSettled(allocator, &client, &.{}, .{});
     defer allocator.free(results);
     try std.testing.expectEqual(@as(usize, 0), results.len);
 }
@@ -444,3 +719,43 @@ test "RequestResult summary helpers" {
     try std.testing.expectEqual(@as(usize, 0), successfulCount(&results));
     try std.testing.expectEqual(@as(usize, 2), errorCount(&results));
 }
+
+test "ConcurrencyConfig modes execution" {
+    const allocator = std.testing.allocator;
+    var client = Client.init(allocator);
+    defer client.deinit();
+
+    const specs = [_]RequestSpec{
+        .{ .method = .GET, .url = "http://127.0.0.1:0" },
+        .{ .method = .GET, .url = "http://127.0.0.1:0" },
+    };
+
+    // 1. Test single_thread mode
+    const st_results = try all(allocator, &client, &specs, .{ .mode = .single_thread });
+    defer allocator.free(st_results);
+    try std.testing.expectEqual(specs.len, st_results.len);
+    for (st_results) |r| {
+        try std.testing.expect(!r.isSuccess());
+    }
+
+    // 2. Test multi_thread mode (implicit workers)
+    const mt_results = try all(allocator, &client, &specs, .{ .mode = .multi_thread, .workers = 2 });
+    defer allocator.free(mt_results);
+    try std.testing.expectEqual(specs.len, mt_results.len);
+    for (mt_results) |r| {
+        try std.testing.expect(!r.isSuccess());
+    }
+
+    // 3. Test explicit_workers mode
+    var exec = @import("executor.zig").Executor.initWithConfig(allocator, .{ .num_threads = 2 });
+    defer exec.deinit();
+    try exec.start();
+
+    const ex_results = try all(allocator, &client, &specs, .{ .mode = .explicit_workers, .executor = &exec });
+    defer allocator.free(ex_results);
+    try std.testing.expectEqual(specs.len, ex_results.len);
+    for (ex_results) |r| {
+        try std.testing.expect(!r.isSuccess());
+    }
+}
+

--- a/src/core/meta.zig
+++ b/src/core/meta.zig
@@ -2,7 +2,7 @@
 
 const std = @import("std");
 
-pub const version = "0.1.0";
+pub const version = "0.1.1";
 pub const user_agent_prefix = "httpx.zig/";
 pub const default_user_agent = user_agent_prefix ++ version;
 
@@ -13,14 +13,8 @@ test "default_user_agent is prefix plus version" {
 }
 
 test "version has numeric semver core" {
-    var it = std.mem.splitScalar(u8, version, '.');
-    var part_count: usize = 0;
-
-    while (it.next()) |part| {
-        part_count += 1;
-        try std.testing.expect(part.len > 0);
-        _ = try std.fmt.parseUnsigned(u32, part, 10);
-    }
-
-    try std.testing.expectEqual(@as(usize, 3), part_count);
+    const parsed = try std.SemanticVersion.parse(version);
+    try std.testing.expectEqual(@as(u64, 0), parsed.major);
+    try std.testing.expectEqual(@as(u64, 1), parsed.minor);
+    try std.testing.expectEqual(@as(u64, 1), parsed.patch);
 }

--- a/src/core/request.zig
+++ b/src/core/request.zig
@@ -97,13 +97,7 @@ pub const Request = struct {
 
     /// Sets the Authorization header using HTTP Basic authentication.
     pub fn setBasicAuth(self: *Self, username: []const u8, password: []const u8) !void {
-        const credentials = try std.fmt.allocPrint(self.allocator, "{s}:{s}", .{ username, password });
-        defer self.allocator.free(credentials);
-
-        const encoded = try Base64.encode(self.allocator, credentials);
-        defer self.allocator.free(encoded);
-
-        const auth_value = try std.fmt.allocPrint(self.allocator, "Basic {s}", .{encoded});
+        const auth_value = try Base64.formatBasicAuth(self.allocator, username, password);
         defer self.allocator.free(auth_value);
 
         try self.headers.set(HeaderName.AUTHORIZATION, auth_value);

--- a/src/core/types.zig
+++ b/src/core/types.zig
@@ -383,6 +383,14 @@ pub const Http3Settings = struct {
     enable_datagrams: bool = false,
 };
 
+/// Proxy configuration settings.
+pub const Proxy = struct {
+    host: []const u8,
+    port: u16,
+    username: ?[]const u8 = null,
+    password: ?[]const u8 = null,
+};
+
 test "Method.fromString" {
     try std.testing.expectEqual(Method.GET, Method.fromString("GET").?);
     try std.testing.expectEqual(Method.POST, Method.fromString("POST").?);

--- a/src/httpx.zig
+++ b/src/httpx.zig
@@ -103,7 +103,6 @@ pub const encoding = @import("util/encoding.zig");
 pub const json = @import("util/json.zig");
 pub const mime = @import("util/mime.zig");
 pub const common = @import("util/common.zig");
-pub const utils = common;
 
 pub const executor = @import("concurrency/executor.zig");
 pub const concurrency = @import("concurrency/pool.zig");
@@ -111,6 +110,8 @@ pub const concurrency = @import("concurrency/pool.zig");
 pub const RequestSpec = concurrency.RequestSpec;
 pub const RequestResult = concurrency.RequestResult;
 pub const BatchBuilder = concurrency.BatchBuilder;
+pub const ConcurrencyConfig = concurrency.ConcurrencyConfig;
+pub const ConcurrencyMode = concurrency.ConcurrencyMode;
 
 pub const Executor = executor.Executor;
 pub const Task = executor.Task;
@@ -126,6 +127,7 @@ pub const RetryPolicy = types.RetryPolicy;
 pub const RedirectPolicy = types.RedirectPolicy;
 pub const Http2Settings = types.Http2Settings;
 pub const Http3Settings = types.Http3Settings;
+pub const Proxy = types.Proxy;
 
 pub const Headers = headers.Headers;
 pub const HeaderName = headers.HeaderName;
@@ -209,8 +211,6 @@ pub const BasicAuth = client_mod.BasicAuth;
 pub const Interceptor = client_mod.Interceptor;
 pub const RequestInterceptor = client_mod.RequestInterceptor;
 pub const ResponseInterceptor = client_mod.ResponseInterceptor;
-pub const HttpClient = Client;
-pub const ReqOptions = RequestOptions;
 
 pub const ConnectionPool = pool.ConnectionPool;
 pub const PoolConfig = pool.PoolConfig;
@@ -219,6 +219,8 @@ pub const PoolStats = pool.PoolStats;
 
 pub const Server = server_mod.Server;
 pub const ServerConfig = server_mod.ServerConfig;
+pub const LogLevel = server_mod.LogLevel;
+pub const LogFn = server_mod.LogFn;
 pub const PortConflictStrategy = server_mod.PortConflictStrategy;
 pub const Context = server_mod.Context;
 pub const Handler = server_mod.Handler;
@@ -227,8 +229,6 @@ pub const SameSite = server_mod.SameSite;
 pub const SseEvent = server_mod.SseEvent;
 pub const PreRouteHook = server_mod.PreRouteHook;
 pub const FileResponseOptions = server_mod.FileResponseOptions;
-pub const HttpServer = Server;
-pub const Ctx = Context;
 
 pub const Router = router.Router;
 pub const RouteGroup = router.RouteGroup;
@@ -238,10 +238,13 @@ pub const Middleware = middleware.Middleware;
 pub const Next = middleware.Next;
 pub const cors = middleware.cors;
 pub const logger = middleware.logger;
+pub const LoggerConfig = middleware.LoggerConfig;
+pub const loggerWithConfig = middleware.loggerWithConfig;
 pub const compression = middleware.compression;
 pub const rateLimit = middleware.rateLimit;
 pub const basicAuth = middleware.basicAuth;
 pub const helmet = middleware.helmet;
+pub const reverseProxy = middleware.reverseProxy;
 
 pub const Buffer = buffer.Buffer;
 pub const RingBuffer = buffer.RingBuffer;
@@ -286,14 +289,8 @@ pub const isIp6Address = address.isIp6Address;
 /// Returns a query parameter value from a raw query string.
 pub const queryValue = common.queryValue;
 
-/// Alias for queryValue().
-pub const parseQueryValue = common.queryValue;
-
 /// Parses the first name/value pair from a Set-Cookie header value.
 pub const parseSetCookiePair = common.parseSetCookiePair;
-
-/// Alias for parseSetCookiePair().
-pub const parseCookiePair = common.parseSetCookiePair;
 
 /// Returns a best-effort MIME type from file extension.
 pub const mimeTypeFromPath = common.mimeTypeFromPath;
@@ -311,23 +308,23 @@ pub const encodeVarInt = http.encodeVarInt;
 pub const decodeVarInt = http.decodeVarInt;
 
 /// Executes all requests in parallel and returns a result per request.
-pub fn all(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) ![]RequestResult {
-    return concurrency.all(allocator, client, specs);
+pub fn all(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) ![]RequestResult {
+    return concurrency.all(allocator, client, specs, config);
 }
 
 /// Executes all requests in parallel and returns the first 2xx response (if any).
-pub fn any(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) !?Response {
-    return concurrency.any(allocator, client, specs);
+pub fn any(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !?Response {
+    return concurrency.any(allocator, client, specs, config);
 }
 
 /// Executes all requests in parallel and returns the first completion (success or error).
-pub fn race(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) !RequestResult {
-    return concurrency.race(allocator, client, specs);
+pub fn race(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !RequestResult {
+    return concurrency.race(allocator, client, specs, config);
 }
 
 /// Executes all requests in parallel and returns a settled result for each one.
-pub fn allSettled(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) ![]RequestResult {
-    return concurrency.allSettled(allocator, client, specs);
+pub fn allSettled(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) ![]RequestResult {
+    return concurrency.allSettled(allocator, client, specs, config);
 }
 
 /// Counts successful results returned by all/allSettled.
@@ -341,40 +338,40 @@ pub fn errorCount(results: []const RequestResult) usize {
 }
 
 /// Alias for any() for first-success semantics.
-pub fn first(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) !?Response {
-    return any(allocator, client, specs);
+pub fn first(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !?Response {
+    return any(allocator, client, specs, config);
 }
 
 /// Alias for race() for first-completion semantics.
-pub fn fastest(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) !RequestResult {
-    return race(allocator, client, specs);
+pub fn fastest(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) !RequestResult {
+    return race(allocator, client, specs, config);
 }
 
 /// Alias for allSettled() returning settled outcomes.
-pub fn settled(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec) ![]RequestResult {
-    return allSettled(allocator, client, specs);
+pub fn settled(allocator: std.mem.Allocator, client: *Client, specs: []const RequestSpec, config: ConcurrencyConfig) ![]RequestResult {
+    return allSettled(allocator, client, specs, config);
 }
 
 /// Convenience function to create a GET request.
-pub fn get(url: []const u8) !Response {
-    return getWithAllocator(default_alias_allocator, url);
+pub fn get(url: []const u8, req_options: RequestOptions) !Response {
+    return getWithAllocator(default_alias_allocator, url, req_options);
 }
 
 /// Convenience function to create a GET request with an explicit allocator.
-pub fn getWithAllocator(allocator: std.mem.Allocator, url: []const u8) !Response {
+pub fn getWithAllocator(allocator: std.mem.Allocator, url: []const u8, req_options: RequestOptions) !Response {
     var c = Client.init(allocator);
     defer c.deinit();
-    return c.get(url, .{});
+    return c.get(url, req_options);
 }
 
 /// Convenience alias for GET requests.
-pub fn fetch(url: []const u8) !Response {
-    return get(url);
+pub fn fetch(url: []const u8, req_options: RequestOptions) !Response {
+    return get(url, req_options);
 }
 
 /// Convenience alias for GET requests with an explicit allocator.
-pub fn fetchWithAllocator(allocator: std.mem.Allocator, url: []const u8) !Response {
-    return getWithAllocator(allocator, url);
+pub fn fetchWithAllocator(allocator: std.mem.Allocator, url: []const u8, req_options: RequestOptions) !Response {
+    return getWithAllocator(allocator, url, req_options);
 }
 
 /// Convenience function to create a request with an explicit method.
@@ -523,10 +520,10 @@ pub fn optsWithAllocator(allocator: std.mem.Allocator, url: []const u8, options_
 }
 
 test "top-level alias compile checks" {
-    const get_ptr: *const fn ([]const u8) anyerror!Response = get;
-    const get_alloc_ptr: *const fn (std.mem.Allocator, []const u8) anyerror!Response = getWithAllocator;
-    const fetch_ptr: *const fn ([]const u8) anyerror!Response = fetch;
-    const fetch_alloc_ptr: *const fn (std.mem.Allocator, []const u8) anyerror!Response = fetchWithAllocator;
+    const get_ptr: *const fn ([]const u8, RequestOptions) anyerror!Response = get;
+    const get_alloc_ptr: *const fn (std.mem.Allocator, []const u8, RequestOptions) anyerror!Response = getWithAllocator;
+    const fetch_ptr: *const fn ([]const u8, RequestOptions) anyerror!Response = fetch;
+    const fetch_alloc_ptr: *const fn (std.mem.Allocator, []const u8, RequestOptions) anyerror!Response = fetchWithAllocator;
     const post_json_ptr: *const fn ([]const u8, []const u8) anyerror!Response = postJson;
     const post_json_alloc_ptr: *const fn (std.mem.Allocator, []const u8, []const u8) anyerror!Response = postJsonWithAllocator;
     const send_ptr: *const fn (Method, []const u8, RequestOptions) anyerror!Response = send;
@@ -551,9 +548,9 @@ test "top-level alias compile checks" {
     const options_alloc_ptr: *const fn (std.mem.Allocator, []const u8, RequestOptions) anyerror!Response = optionsWithAllocator;
     const opts_ptr: *const fn ([]const u8, RequestOptions) anyerror!Response = opts;
     const opts_alloc_ptr: *const fn (std.mem.Allocator, []const u8, RequestOptions) anyerror!Response = optsWithAllocator;
-    const first_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec) anyerror!?Response = first;
-    const fastest_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec) anyerror!RequestResult = fastest;
-    const settled_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec) anyerror![]RequestResult = settled;
+    const first_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec, ConcurrencyConfig) anyerror!?Response = first;
+    const fastest_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec, ConcurrencyConfig) anyerror!RequestResult = fastest;
+    const settled_ptr: *const fn (std.mem.Allocator, *Client, []const RequestSpec, ConcurrencyConfig) anyerror![]RequestResult = settled;
     const resolve_addr_ptr: *const fn ([]const u8, u16) anyerror!address.Address = resolveAddress;
     const resolve_all_addr_ptr: *const fn (std.mem.Allocator, []const u8, u16) anyerror![]address.Address = resolveAllAddresses;
     const parse_host_port_ptr = parseHostAndPort;
@@ -673,10 +670,6 @@ test "json" {
 
 test "common" {
     _ = common;
-}
-
-test "utils alias" {
-    _ = utils;
 }
 
 test "socket" {

--- a/src/net/socket.zig
+++ b/src/net/socket.zig
@@ -1153,6 +1153,45 @@ test "Socket read/writeAll compatibility aliases" {
     try std.testing.expectEqualStrings("pong", out_buf[0..n]);
 }
 
+test "SocketIoReader readVec fills internal buffer for empty input" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const ThreadCtx = struct {
+        listener: *TcpListener,
+    };
+    const payload = "hello";
+
+    const server = struct {
+        fn run(ctx: *ThreadCtx) void {
+            var accepted = ctx.listener.accept() catch return;
+            defer accepted.socket.close();
+
+            accepted.socket.writeAll(payload) catch return;
+        }
+    }.run;
+
+    var listener = try TcpListener.init(try net.Address.parseIp("127.0.0.1", 0));
+    defer listener.deinit();
+
+    const addr = try listener.getLocalAddress();
+    var ctx = ThreadCtx{ .listener = &listener };
+    const thread = try std.Thread.spawn(.{}, server, .{&ctx});
+    defer thread.join();
+
+    var client = try Socket.createForAddress(addr);
+    defer client.close();
+
+    try client.connect(addr);
+
+    var scratch: [32]u8 = undefined;
+    var io_reader = SocketIoReader.init(&client, scratch[0..]);
+    var empty_iov = [_][]u8{.{}};
+
+    const n = try SocketIoReader.readVec(&io_reader.reader, &empty_iov);
+    try std.testing.expectEqual(@as(usize, 0), n);
+    try std.testing.expectEqual(payload.len, io_reader.reader.end);
+    try std.testing.expectEqual(@as(usize, 0), io_reader.reader.seek);
+}
+
 test "Socket helper API compile checks" {
     const create_v4_ptr: *const fn () anyerror!Socket = Socket.createV4;
     const create_v6_ptr: *const fn () anyerror!Socket = Socket.createV6;

--- a/src/server/middleware.zig
+++ b/src/server/middleware.zig
@@ -149,8 +149,13 @@ pub fn cors(comptime config: CorsConfig) Middleware {
     };
 }
 
-/// Creates logging middleware.
-pub fn logger() Middleware {
+/// Logger middleware options.
+pub const LoggerConfig = struct {
+    log_fn: ?@import("server.zig").LogFn = null,
+};
+
+/// Creates logging middleware with config.
+pub fn loggerWithConfig(comptime config: LoggerConfig) Middleware {
     return .{
         .name = "logger",
         .handler = struct {
@@ -159,16 +164,28 @@ pub fn logger() Middleware {
                 const response = try next(ctx);
                 const duration = nowMillis() - start;
 
-                std.debug.print("{s} {s} - {d}ms\n", .{
+                var buf: [1024]u8 = undefined;
+                const msg = std.fmt.bufPrint(&buf, "{s} {s} - {d}ms\n", .{
                     ctx.request.method.toString(),
                     ctx.request.uri.path,
                     duration,
-                });
+                }) catch "[Logger format failed or message too long]";
+
+                if (config.log_fn) |f| {
+                    f(.info, msg);
+                } else {
+                    std.debug.print("{s}", .{msg});
+                }
 
                 return response;
             }
         }.handler,
     };
+}
+
+/// Creates logging middleware.
+pub fn logger() Middleware {
+    return loggerWithConfig(.{});
 }
 
 /// Creates compression middleware.
@@ -277,6 +294,42 @@ pub fn requestId() Middleware {
     };
 }
 
+/// Creates reverse proxy middleware that forwards requests to target_url.
+pub fn reverseProxy(comptime target_url: []const u8) Middleware {
+    return .{
+        .name = "reverse_proxy",
+        .handler = struct {
+            fn handler(ctx: *Context, next: Next) anyerror!Response {
+                _ = next;
+                const client_mod = @import("../client/client.zig");
+                var client = client_mod.Client.init(ctx.allocator);
+                defer client.deinit();
+
+                const path = ctx.request.uri.path;
+                const query_str = ctx.request.uri.query;
+                const full_target = if (query_str) |q|
+                    try std.fmt.allocPrint(ctx.allocator, "{s}{s}?{s}", .{ target_url, path, q })
+                else
+                    try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ target_url, path });
+                defer ctx.allocator.free(full_target);
+
+                var headers_list = std.ArrayList([2][]const u8).empty;
+                defer headers_list.deinit(ctx.allocator);
+                for (ctx.request.headers.entries.items) |h| {
+                    if (std.ascii.eqlIgnoreCase(h.name, "host")) continue;
+                    try headers_list.append(ctx.allocator, .{ h.name, h.value });
+                }
+
+                var req_opts = client_mod.RequestOptions.defaults();
+                req_opts.headers = headers_list.items;
+                req_opts.body = ctx.request.body;
+
+                return client.request(ctx.request.method, full_target, req_opts);
+            }
+        }.handler,
+    };
+}
+
 test "Middleware creation" {
     const mw = logger();
     try std.testing.expectEqualStrings("logger", mw.name);
@@ -297,4 +350,42 @@ test "Rate limit middleware" {
 test "Helmet middleware" {
     const mw = helmet();
     try std.testing.expectEqualStrings("helmet", mw.name);
+}
+
+test "Reverse proxy middleware creation" {
+    const mw = reverseProxy("http://127.0.0.1:9090");
+    try std.testing.expectEqualStrings("reverse_proxy", mw.name);
+}
+
+test "loggerWithConfig middleware" {
+    const CustomLogger = struct {
+        var logged: bool = false;
+        fn log_fn(level: @import("server.zig").LogLevel, message: []const u8) void {
+            _ = level;
+            if (std.mem.indexOf(u8, message, "GET /test") != null) {
+                logged = true;
+            }
+        }
+    };
+
+    const mw = loggerWithConfig(.{ .log_fn = CustomLogger.log_fn });
+    try std.testing.expectEqualStrings("logger", mw.name);
+
+    var req = try @import("../core/request.zig").Request.init(std.testing.allocator, .GET, "/test");
+    defer req.deinit();
+
+    var ctx = Context.init(std.testing.allocator, &req);
+    defer ctx.deinit();
+
+    const NextMock = struct {
+        fn next(c: *Context) anyerror!Response {
+            _ = c;
+            return Response.init(std.testing.allocator);
+        }
+    };
+
+    var res = try mw.handler(&ctx, NextMock.next);
+    defer res.deinit();
+
+    try std.testing.expect(CustomLogger.logged);
 }

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -68,6 +68,15 @@ pub const SseEvent = struct {
 /// Pre-route hook called after parsing the request and before route matching.
 pub const PreRouteHook = *const fn (*Context) anyerror!void;
 
+pub const LogLevel = enum {
+    debug,
+    info,
+    warn,
+    err,
+};
+
+pub const LogFn = *const fn (level: LogLevel, message: []const u8) void;
+
 /// Server configuration.
 pub const ServerConfig = struct {
     host: []const u8 = "127.0.0.1",
@@ -84,6 +93,7 @@ pub const ServerConfig = struct {
     http3_enabled: bool = false,
     http2_settings: types.Http2Settings = .{},
     http3_settings: types.Http3Settings = .{},
+    log_fn: ?LogFn = null,
 };
 
 /// File-serving options used by `Context.fileWithOptions`.
@@ -502,6 +512,35 @@ pub const Server = struct {
         return self.listenTcp();
     }
 
+    /// Spawns a background thread to run the server's listening loop.
+    /// The caller is responsible for joining the returned Thread.
+    pub fn listenInBackground(self: *Self) !std.Thread {
+        return std.Thread.spawn(.{}, struct {
+            fn run(s: *Self) void {
+                s.listen() catch |err| {
+                    if (s.running) {
+                        s.log(.err, "server error: {s}\n", .{@errorName(err)});
+                    }
+                };
+            }
+        }.run, .{self});
+    }
+
+    /// Logs a formatted message. If config.log_fn is provided, delegates to it.
+    /// Otherwise, prints to stderr.
+    pub fn log(self: *const Self, level: LogLevel, comptime format: []const u8, args: anytype) void {
+        if (self.config.log_fn) |log_fn| {
+            var buf: [1024]u8 = undefined;
+            if (std.fmt.bufPrint(&buf, format, args)) |msg| {
+                log_fn(level, msg);
+            } else |_| {
+                log_fn(level, "[Log format failed or message too long]");
+            }
+        } else {
+            std.debug.print(format, args);
+        }
+    }
+
     /// Returns the effective server port (useful when `port_conflict = .increment`).
     pub fn listeningPort(self: *const Self) u16 {
         return self.config.port;
@@ -584,17 +623,17 @@ pub const Server = struct {
         try self.bindTcpListener(backlog);
         self.running = true;
 
-        std.debug.print("Server listening on {s}:{d}\n", .{ self.config.host, self.config.port });
+        self.log(.info, "Server listening on {s}:{d}\n", .{ self.config.host, self.config.port });
 
         while (self.running) {
             const conn = self.listener.?.accept() catch |err| {
                 if (!self.running) break;
-                std.debug.print("Accept error: {}\n", .{err});
+                self.log(.err, "Accept error: {}\n", .{err});
                 continue;
             };
 
             self.handleConnection(conn.socket) catch |err| {
-                std.debug.print("Handler error: {}\n", .{err});
+                self.log(.err, "Handler error: {}\n", .{err});
             };
         }
     }
@@ -603,19 +642,19 @@ pub const Server = struct {
         try self.bindUdpSocket();
         self.running = true;
 
-        std.debug.print("Server listening (HTTP/3) on {s}:{d}\n", .{ self.config.host, self.config.port });
+        self.log(.info, "Server listening (HTTP/3) on {s}:{d}\n", .{ self.config.host, self.config.port });
 
         var recv_buf: [64 * 1024]u8 = undefined;
 
         while (self.running) {
             const incoming = self.udp_socket.?.recvFrom(&recv_buf) catch |err| {
                 if (!self.running) break;
-                std.debug.print("HTTP/3 recv error: {}\n", .{err});
+                self.log(.err, "HTTP/3 recv error: {}\n", .{err});
                 continue;
             };
 
             self.handleHttp3Transaction(incoming.addr, recv_buf[0..incoming.n]) catch |err| {
-                std.debug.print("HTTP/3 handler error: {}\n", .{err});
+                self.log(.err, "HTTP/3 handler error: {}\n", .{err});
             };
         }
     }
@@ -680,7 +719,7 @@ pub const Server = struct {
             }
 
             var response = self.executeServerRequest(&req) catch |err| {
-                std.debug.print("Handler error: {}\n", .{err});
+                self.log(.err, "Handler error: {}\n", .{err});
                 return self.sendError(&sock, 500);
             };
 
@@ -1650,6 +1689,12 @@ test "Server initialization" {
     defer server.deinit();
 
     try std.testing.expectEqual(@as(u16, 8080), server.config.port);
+    try std.testing.expectEqualStrings("127.0.0.1", server.config.host);
+    try std.testing.expectEqual(@as(u32, 1000), server.config.max_connections);
+    try std.testing.expectEqual(@as(u64, 30_000), server.config.request_timeout_ms);
+    try std.testing.expectEqual(@as(u64, 60_000), server.config.keep_alive_timeout_ms);
+    try std.testing.expectEqual(@as(u32, 0), server.config.threads);
+    try std.testing.expect(server.config.keep_alive);
 }
 
 test "Context response helpers" {
@@ -1953,4 +1998,22 @@ test "Server port conflict strategy increment for HTTP/3 UDP" {
 
     try std.testing.expect(server.udp_socket != null);
     try std.testing.expect(server.config.port != reserved.port);
+}
+
+test "Server custom log callback" {
+    const allocator = std.testing.allocator;
+    const CustomLogger = struct {
+        var logged: bool = false;
+        fn log_fn(level: LogLevel, message: []const u8) void {
+            if (level == .info and std.mem.indexOf(u8, message, "test log message") != null) {
+                logged = true;
+            }
+        }
+    };
+
+    const server = Server.initWithConfig(allocator, .{
+        .log_fn = CustomLogger.log_fn,
+    });
+    server.log(.info, "this is a {s} message", .{"test log message"});
+    try std.testing.expect(CustomLogger.logged);
 }

--- a/src/util/encoding.zig
+++ b/src/util/encoding.zig
@@ -13,91 +13,49 @@ const list_writer = @import("list_writer.zig");
 
 /// Base64 encoding and decoding per RFC 4648.
 pub const Base64 = struct {
-    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    const url_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
-
     /// Encodes data to standard Base64.
     pub fn encode(allocator: Allocator, data: []const u8) ![]u8 {
-        const len = ((data.len + 2) / 3) * 4;
-        var result = try allocator.alloc(u8, len);
-        var i: usize = 0;
-        var j: usize = 0;
-
-        while (i < data.len) {
-            const b0 = data[i];
-            const b1 = if (i + 1 < data.len) data[i + 1] else 0;
-            const b2 = if (i + 2 < data.len) data[i + 2] else 0;
-
-            result[j] = alphabet[b0 >> 2];
-            result[j + 1] = alphabet[((b0 & 0x03) << 4) | (b1 >> 4)];
-            result[j + 2] = if (i + 1 < data.len) alphabet[((b1 & 0x0F) << 2) | (b2 >> 6)] else '=';
-            result[j + 3] = if (i + 2 < data.len) alphabet[b2 & 0x3F] else '=';
-
-            i += 3;
-            j += 4;
-        }
-
+        const len = std.base64.standard.Encoder.calcSize(data.len);
+        const result = try allocator.alloc(u8, len);
+        _ = std.base64.standard.Encoder.encode(result, data);
         return result;
     }
 
     /// Decodes Base64 data.
     pub fn decode(allocator: Allocator, data: []const u8) ![]u8 {
-        if (data.len == 0) return allocator.alloc(u8, 0);
-        if (data.len % 4 != 0) return error.InvalidBase64;
-
-        var padding: usize = 0;
-        if (data[data.len - 1] == '=') padding += 1;
-        if (data[data.len - 2] == '=') padding += 1;
-
-        const out_len = (data.len / 4) * 3 - padding;
-        var result = try allocator.alloc(u8, out_len);
-        var i: usize = 0;
-        var j: usize = 0;
-
-        while (i < data.len) {
-            const c0 = indexOf(alphabet, data[i]) orelse return error.InvalidBase64;
-            const c1 = indexOf(alphabet, data[i + 1]) orelse return error.InvalidBase64;
-            const c2 = if (data[i + 2] == '=') @as(u6, 0) else indexOf(alphabet, data[i + 2]) orelse return error.InvalidBase64;
-            const c3 = if (data[i + 3] == '=') @as(u6, 0) else indexOf(alphabet, data[i + 3]) orelse return error.InvalidBase64;
-
-            if (j < out_len) result[j] = (@as(u8, c0) << 2) | (@as(u8, c1) >> 4);
-            if (j + 1 < out_len) result[j + 1] = (@as(u8, c1) << 4) | (@as(u8, c2) >> 2);
-            if (j + 2 < out_len) result[j + 2] = (@as(u8, c2) << 6) | @as(u8, c3);
-
-            i += 4;
-            j += 3;
-        }
-
+        const len = try std.base64.standard.Decoder.calcSizeForSlice(data);
+        const result = try allocator.alloc(u8, len);
+        try std.base64.standard.Decoder.decode(result, data);
         return result;
     }
 
     /// Encodes to URL-safe Base64 (no padding).
     pub fn encodeUrl(allocator: Allocator, data: []const u8) ![]u8 {
-        const result = try encode(allocator, data);
-        for (result) |*c| {
-            if (c.* == '+') c.* = '-';
-            if (c.* == '/') c.* = '_';
-        }
-        var end = result.len;
-        while (end > 0 and result[end - 1] == '=') end -= 1;
-        return allocator.realloc(result, end);
+        const len = std.base64.url_safe_no_pad.Encoder.calcSize(data.len);
+        const result = try allocator.alloc(u8, len);
+        _ = std.base64.url_safe_no_pad.Encoder.encode(result, data);
+        return result;
     }
 
-    fn indexOf(chars: []const u8, c: u8) ?u6 {
-        for (chars, 0..) |ch, i| {
-            if (ch == c) return @intCast(i);
-        }
-        return null;
+    /// Formats a Basic authentication header value.
+    /// The caller owns the returned slice.
+    pub fn formatBasicAuth(allocator: Allocator, username: []const u8, password: []const u8) ![]u8 {
+        const credentials = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ username, password });
+        defer allocator.free(credentials);
+
+        const encoded = try Base64.encode(allocator, credentials);
+        defer allocator.free(encoded);
+
+        return std.fmt.allocPrint(allocator, "Basic {s}", .{encoded});
     }
 };
 
 /// Hexadecimal encoding and decoding.
 pub const Hex = struct {
-    const hex_chars = "0123456789abcdef";
-
     /// Encodes data to lowercase hexadecimal.
     pub fn encode(allocator: Allocator, data: []const u8) ![]u8 {
         var result = try allocator.alloc(u8, data.len * 2);
+        const hex_chars = "0123456789abcdef";
         for (data, 0..) |byte, i| {
             result[i * 2] = hex_chars[byte >> 4];
             result[i * 2 + 1] = hex_chars[byte & 0x0F];
@@ -108,23 +66,9 @@ pub const Hex = struct {
     /// Decodes hexadecimal data.
     pub fn decode(allocator: Allocator, data: []const u8) ![]u8 {
         if (data.len % 2 != 0) return error.InvalidHex;
-
-        var result = try allocator.alloc(u8, data.len / 2);
-        var i: usize = 0;
-        while (i < data.len) {
-            const high = hexValue(data[i]) orelse return error.InvalidHex;
-            const low = hexValue(data[i + 1]) orelse return error.InvalidHex;
-            result[i / 2] = (high << 4) | low;
-            i += 2;
-        }
+        const result = try allocator.alloc(u8, data.len / 2);
+        _ = std.fmt.hexToBytes(result, data) catch return error.InvalidHex;
         return result;
-    }
-
-    fn hexValue(c: u8) ?u8 {
-        if (c >= '0' and c <= '9') return c - '0';
-        if (c >= 'a' and c <= 'f') return c - 'a' + 10;
-        if (c >= 'A' and c <= 'F') return c - 'A' + 10;
-        return null;
     }
 };
 


### PR DESCRIPTION
## [0.1.1] 

### Added
- Added client-side forward proxy support (supporting HTTP/HTTPS proxies, custom proxy authentication, CONNECT tunnels for TLS/HTTP2, and absolute URLs for HTTP/1.x) for the request tracked in [Issue #15](https://github.com/muhammad-fiaz/httpx.zig/issues/15).
- Added server-side reverse proxy middleware `reverseProxy(comptime target_url: []const u8)` to forward incoming requests to backends.
- Added Zig 0.15 deprecation warnings in documentation.
- Added three execution modes for client-side requests (`single_thread`, `multi_thread` with dynamic background workers, and `explicit_workers` using an existing thread pool).
- Added `Server.listenInBackground()` to spin up the server event loop asynchronously in one call.
- Added customizable logging support via `ServerConfig.log_fn` and `loggerWithConfig()` middleware to support integrating custom logging frameworks.

### Changed
- Bumped project version to `0.1.1`.
- Cleaned up redundant and duplicate aliases to simplify the public API surface (removed type aliases `HttpClient`, `ReqOptions`, `HttpServer`, `Ctx`, utility function aliases `parseQueryValue`, `parseCookiePair`, `utils`, and client alias `httpOptions`).
- Updated minimum Zig version to `0.16.0`.
- Updated concurrent request functions (`all`, `allSettled`, `any`, `race`, `first`, `fastest`, `settled`) to accept a `ConcurrencyConfig`.
- Aligned top-level package request wrappers (`get`, `getWithAllocator`, `fetch`, `fetchWithAllocator`) to accept `RequestOptions` for consistency with all other HTTP verb wrappers.
- Expanded documentation coverage for client/server/network/protocol/sockets, proxy support, JSON helpers, logging callbacks, and the new `0.1.0` install path.

### Fixed
- Fixed HTTPS client TLS handshakes on Zig `0.16` by honoring `std.Io.Reader.fillUnbuffered`'s empty-buffer `readVec` contract in `src/net/socket.zig`, resolving `error.TlsConnectionTruncated` on simple GET requests. This addresses [Issue #14](https://github.com/muhammad-fiaz/httpx.zig/issues/14).
- Fixed thread join hangs and socket/listener deinitialization sequence deadlocks in all runtime examples on scope exit.
- Added comprehensive end-to-end runnable `proxy_example` demonstrating client forward proxying and server reverse proxy middleware.
- Added unit tests for client-side proxy request formatting and base64 proxy authentication encoding.