### PR TITLE
sleep for one nanosecond before starting the unix listener

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -922,6 +922,8 @@ pub const Server = struct {
     }
 
     fn listenUnix(self: *Self, path: []const u8) !void {
+        try std.Io.sleep(defaultIo(), .fromNanoseconds(1), .real);
+
         if (self.unix_listener == null) {
             const unix_mod = @import("../net/unix.zig");
             self.unix_listener = try unix_mod.UnixListener.init(path);


### PR DESCRIPTION
## Description

Added a one nanosecond sleep before starting the unix listener.
Without the sleep I get this error:
```zig
Server listening on Unix socket: ./ipc.sock
thread 130929 panic: attempt to use null value
/home/###/Documents/###/zig-pkg/httpx-0.1.5-8qj2elGlFQAoJQ22AGRef6ckhz_R_RaJ1hkrSiQNrjor/src/server/server.zig:940:44: 0x1226927 in listenUnix (httpx.zig)
            const conn = self.unix_listener.?.accept() catch |err| {
                                           ^
/home/###/Documents/###/zig-pkg/httpx-0.1.5-8qj2elGlFQAoJQ22AGRef6ckhz_R_RaJ1hkrSiQNrjor/src/server/server.zig:532:35: 0x124f03c in listen (httpx.zig)
            return self.listenUnix(path);
                                  ^
/home/###/Documents/###/zig-pkg/httpx-0.1.5-8qj2elGlFQAoJQ22AGRef6ckhz_R_RaJ1hkrSiQNrjor/src/server/server.zig:582:29: 0x140af7d in run (httpx.zig)
                    s.listen() catch |err| {
                            ^
/usr/lib64/zig/0.16.0/lib/std/Thread.zig:422:13: 0x140af05 in callFn__anon_354944 (std.zig)
            @call(.auto, f, args);
            ^
/usr/lib64/zig/0.16.0/lib/std/Thread.zig:752:30: 0x140ace9 in entryFn (std.zig)
                return callFn(f, args_ptr.*);
                             ^
???:?:?: 0x7ff4d482e55e in ??? (/usr/lib64/libc.so.6)
???:?:?: 0x7ff4d48ad5ab in ??? (/usr/lib64/libc.so.6)
start
└─ run exe ipc-server failure
error: process terminated with signal ABRT
```

With the sleep added it no longer errors out. If this wasn't the correct approach I will attempt a better fix with some guidance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
